### PR TITLE
automate production deploy

### DIFF
--- a/cloudbuild-prod.yaml
+++ b/cloudbuild-prod.yaml
@@ -1,0 +1,53 @@
+steps:
+  # Docker Auth
+  - name: 'gcr.io/cloud-builders/gcloud'
+    id: "google cloud docker auth"
+    entrypoint: sh
+    args:
+    - "-c"
+    - |
+      gcloud auth configure-docker europe-west2-docker.pkg.dev
+
+  # Docker Build
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-prod:${SHORT_SHA}', '-t', 'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-prod:latest',  '.' ]
+
+  # Docker push to Google Artifact Registry
+  - name: 'gcr.io/cloud-builders/docker'
+    args: [ 'push',  'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-prod:${SHORT_SHA}' ]
+
+  # Docker push latest tag to Google Artifact Registry
+  - name: 'gcr.io/cloud-builders/docker'
+    args: [ 'push',  'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-prod:latest' ]
+
+  # Runs the Docker image pushed
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    id: "Run image"
+    entrypoint: gcloud
+    args: [ 'run', 'deploy', 'sds', '--image', 'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-prod:$SHORT_SHA',
+            '--region', 'europe-west2' ]
+
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    id: "Deploy cloud function"
+    entrypoint: sh
+    args:
+      - '-c'
+      - |
+        cd src/app/
+        gcloud functions deploy new-dataset-function \
+        --gen2 \
+        --runtime=python311 \
+        --region=europe-west2 \
+        --source=. \
+        --entry-point=new_dataset \
+        --trigger-event-filters="type=google.cloud.storage.object.v1.finalized" \
+        --trigger-event-filters="bucket=${_DATASET_BUCKET_NAME}" \
+        --set-env-vars="DATASET_BUCKET_NAME=${_DATASET_BUCKET_NAME},SCHEMA_BUCKET_NAME=${_SCHEMA_BUCKET_NAME},CONF=cloud-build,AUTODELETE_DATASET_BUCKET_FILE=${_AUTODELETE_DATASET_BUCKET_FILE},LOG_LEVEL=${_LOG_LEVEL},PROJECT_ID=${_PROJECT_ID}"
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+
+# Store images in Google Artifact Registry
+images:
+  - europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-prod:${SHORT_SHA}
+  - europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-prod:latest


### PR DESCRIPTION
### Motivation and Context
To automate the cloud build by triggering the process using a GitHub tag (release-v.x.x.x) and to automate the cloud function build

### What has changed
Added a .yaml file to be triggered at a production release to automate the cloud build of the app and cloud function 

### How to test?
Tested in individual sandbox
