### PR TITLE
Sdss 115 add load balancer to lower region

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ integration-test-local:
 	export PROJECT_ID=mock-project-id && \
 	export PUBLISH_SCHEMA_TOPIC_ID=${PUBLISH_SCHEMA_TOPIC_ID} && \
 	export PUBLISH_DATASET_TOPIC_ID=${PUBLISH_DATASET_TOPIC_ID} && \
-	export LOAD_BALANCER_ADDRESS=${LOCAL_URL} && \
+	export API_URL=${LOCAL_URL} && \
 	export OAUTH_CLIENT_ID=${LOCAL_URL} && \
 	python -m pytest src/integration_tests -vv -W ignore::DeprecationWarning
 
@@ -97,7 +97,7 @@ integration-test-sandbox:
 	export PROJECT_ID=$(PROJECT_ID) && \
 	export PUBLISH_SCHEMA_TOPIC_ID=${PUBLISH_SCHEMA_TOPIC_ID} && \
 	export PUBLISH_DATASET_TOPIC_ID=${PUBLISH_DATASET_TOPIC_ID} && \
-	export LOAD_BALANCER_ADDRESS=https://34.36.238.222.nip.io && \
+	export API_URL=https://34.36.238.222.nip.io && \
 	export OAUTH_CLIENT_ID=293516424663-6ebeaknvn4b3s6lplvo6v12trahghfsc.apps.googleusercontent.com && \
 	python -m pytest src/integration_tests -vv -W ignore::DeprecationWarning
 
@@ -114,7 +114,7 @@ integration-test-cloudbuild:
 	export PROJECT_ID=${INT_PROJECT_ID} && \
 	export PUBLISH_SCHEMA_TOPIC_ID=${INT_PUBLISH_SCHEMA_TOPIC_ID} && \
 	export PUBLISH_DATASET_TOPIC_ID=${INT_PUBLISH_DATASET_TOPIC_ID} && \
-	export LOAD_BALANCER_ADDRESS=${INT_LOAD_BALANCER_ADDRESS} && \
+	export API_URL=${INT_API_URL} && \
 	export OAUTH_CLIENT_ID=${INT_OAUTH_CLIENT_ID} && \
 	python -m pytest src/integration_tests -vv -W ignore::DeprecationWarning
 

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,8 @@ integration-test-local:
 	export PROJECT_ID=mock-project-id && \
 	export PUBLISH_SCHEMA_TOPIC_ID=${PUBLISH_SCHEMA_TOPIC_ID} && \
 	export PUBLISH_DATASET_TOPIC_ID=${PUBLISH_DATASET_TOPIC_ID} && \
+	export LOAD_BALANCER_ADDRESS=${API_URL} && \
+	export OAUTH_CLIENT_ID=${API_URL} && \
 	python -m pytest src/integration_tests -vv -W ignore::DeprecationWarning
 
 integration-test-sandbox:
@@ -97,6 +99,8 @@ integration-test-sandbox:
 	export PROJECT_ID=$(PROJECT_ID) && \
 	export PUBLISH_SCHEMA_TOPIC_ID=${PUBLISH_SCHEMA_TOPIC_ID} && \
 	export PUBLISH_DATASET_TOPIC_ID=${PUBLISH_DATASET_TOPIC_ID} && \
+	export LOAD_BALANCER_ADDRESS=https://34.36.238.222.nip.io && \
+	export OAUTH_CLIENT_ID=293516424663-6ebeaknvn4b3s6lplvo6v12trahghfsc.apps.googleusercontent.com && \
 	python -m pytest src/integration_tests -vv -W ignore::DeprecationWarning
 
 #For use only by automated cloudbuild, is not intended to work locally. 
@@ -114,6 +118,8 @@ integration-test-cloudbuild:
 	export PROJECT_ID=${INT_PROJECT_ID} && \
 	export PUBLISH_SCHEMA_TOPIC_ID=${INT_PUBLISH_SCHEMA_TOPIC_ID} && \
 	export PUBLISH_DATASET_TOPIC_ID=${INT_PUBLISH_DATASET_TOPIC_ID} && \
+	export LOAD_BALANCER_ADDRESS=${INT_LOAD_BALANCER_ADDRESS} && \
+	export OAUTH_CLIENT_ID=${INT_OAUTH_CLIENT_ID} && \
 	python -m pytest src/integration_tests -vv -W ignore::DeprecationWarning
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ GOOGLE_APPLICATION_CREDENTIALS=sandbox-key.json
 AUTODELETE_DATASET_BUCKET_FILE=True
 LOG_LEVEL=INFO
 PROJECT_ID = $(shell gcloud config get project)
+OAUTH_BRAND_NAME = $(shell gcloud iap oauth-brands list --format='value(name)' --limit=1 --project=$(PROJECT_ID))
+OAUTH_CLIENT_NAME = $(shell gcloud iap oauth-clients list $(OAUTH_BRAND_NAME) --format='value(name)' \
+        --limit=1)
+OAUTH_CLIENT_ID = $(shell echo $(OAUTH_CLIENT_NAME)| cut -d'/' -f 6)
 LOCAL_URL:=http://localhost:3000
 PUBLISH_SCHEMA_TOPIC_ID=ons-sds-publish-schema
 PUBLISH_DATASET_TOPIC_ID=ons-sds-publish-dataset
@@ -98,7 +102,7 @@ integration-test-sandbox:
 	export PUBLISH_SCHEMA_TOPIC_ID=${PUBLISH_SCHEMA_TOPIC_ID} && \
 	export PUBLISH_DATASET_TOPIC_ID=${PUBLISH_DATASET_TOPIC_ID} && \
 	export API_URL=https://34.36.238.222.nip.io && \
-	export OAUTH_CLIENT_ID=293516424663-6ebeaknvn4b3s6lplvo6v12trahghfsc.apps.googleusercontent.com && \
+	export OAUTH_CLIENT_ID=${OAUTH_CLIENT_ID} && \
 	python -m pytest src/integration_tests -vv -W ignore::DeprecationWarning
 
 #For use only by automated cloudbuild, is not intended to work locally. 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GOOGLE_APPLICATION_CREDENTIALS=sandbox-key.json
 AUTODELETE_DATASET_BUCKET_FILE=True
 LOG_LEVEL=INFO
 PROJECT_ID = $(shell gcloud config get project)
-API_URL:=http://localhost:3000
+LOCAL_URL:=http://localhost:3000
 PUBLISH_SCHEMA_TOPIC_ID=ons-sds-publish-schema
 PUBLISH_DATASET_TOPIC_ID=ons-sds-publish-dataset
 
@@ -78,13 +78,12 @@ integration-test-local:
     export SCHEMA_BUCKET_NAME=ons-sds-sandbox-01-europe-west2-schema-892a && \
 	export TEST_DATASET_PATH=${TEST_DATASET_PATH} && \
 	export TEST_SCHEMA_PATH=${TEST_SCHEMA_PATH} && \
-    export API_URL=${API_URL} && \
 	export GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS} && \
 	export PROJECT_ID=mock-project-id && \
 	export PUBLISH_SCHEMA_TOPIC_ID=${PUBLISH_SCHEMA_TOPIC_ID} && \
 	export PUBLISH_DATASET_TOPIC_ID=${PUBLISH_DATASET_TOPIC_ID} && \
-	export LOAD_BALANCER_ADDRESS=${API_URL} && \
-	export OAUTH_CLIENT_ID=${API_URL} && \
+	export LOAD_BALANCER_ADDRESS=${LOCAL_URL} && \
+	export OAUTH_CLIENT_ID=${LOCAL_URL} && \
 	python -m pytest src/integration_tests -vv -W ignore::DeprecationWarning
 
 integration-test-sandbox:
@@ -94,7 +93,6 @@ integration-test-sandbox:
     export SCHEMA_BUCKET_NAME=ons-sds-sandbox-01-europe-west2-schema-892a && \
 	export TEST_DATASET_PATH=${TEST_DATASET_PATH} && \
 	export TEST_SCHEMA_PATH=${TEST_SCHEMA_PATH} && \
-    export API_URL=https://sds-jjpah7fbzq-nw.a.run.app && \
 	export GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS} && \
 	export PROJECT_ID=$(PROJECT_ID) && \
 	export PUBLISH_SCHEMA_TOPIC_ID=${PUBLISH_SCHEMA_TOPIC_ID} && \
@@ -111,8 +109,6 @@ integration-test-cloudbuild:
     export SCHEMA_BUCKET_NAME=${INT_SCHEMA_BUCKET_NAME} && \
 	export TEST_DATASET_PATH=${TEST_DATASET_PATH} && \
 	export TEST_SCHEMA_PATH=${TEST_SCHEMA_PATH} && \
-    export API_URL=${INT_API_URL} && \
-	export ACCESS_TOKEN=${ACCESS_TOKEN} && \
 	export AUTODELETE_DATASET_BUCKET_FILE=${INT_AUTODELETE_DATASET_BUCKET_FILE} && \
 	export LOG_LEVEL=${INT_LOG_LEVEL} && \
 	export PROJECT_ID=${INT_PROJECT_ID} && \

--- a/cloudbuild-preprod.yaml
+++ b/cloudbuild-preprod.yaml
@@ -25,7 +25,7 @@ steps:
     id: "Run image"
     entrypoint: gcloud
     args: [ 'run', 'deploy', 'sds', '--image', 'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-preprod:$SHORT_SHA',
-            '--region', 'europe-west2' ]
+            '--region', 'europe-west2', '--allow-unauthenticated', '--ingress', 'internal-and-cloud-load-balancing' ]
 
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: "Deploy cloud function"
@@ -35,7 +35,9 @@ steps:
       - |
         cd src/app/
         gcloud functions deploy new-dataset-function \
+        --allow-unauthenticated \
         --gen2 \
+        --ingress-settings=internal-and-gclb \
         --runtime=python311 \
         --region=europe-west2 \
         --source=. \

--- a/cloudbuild-prod.yaml
+++ b/cloudbuild-prod.yaml
@@ -25,7 +25,7 @@ steps:
     id: "Run image"
     entrypoint: gcloud
     args: [ 'run', 'deploy', 'sds', '--image', 'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-prod:$SHORT_SHA',
-            '--region', 'europe-west2' ]
+            '--region', 'europe-west2', '--allow-unauthenticated', '--ingress', 'internal-and-cloud-load-balancing' ]
 
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: "Deploy cloud function"
@@ -35,7 +35,9 @@ steps:
       - |
         cd src/app/
         gcloud functions deploy new-dataset-function \
+        --allow-unauthenticated \
         --gen2 \
+        --ingress-settings=internal-and-gclb \
         --runtime=python311 \
         --region=europe-west2 \
         --source=. \

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -83,6 +83,9 @@ steps:
         export INT_SCHEMA_BUCKET_NAME=$_SCHEMA_BUCKET_NAME
         export INT_PUBLISH_SCHEMA_TOPIC_ID=$_PUBLISH_SCHEMA_TOPIC_ID
         export INT_PUBLISH_DATASET_TOPIC_ID=$_PUBLISH_DATASET_TOPIC_ID
+        export INT_LOAD_BALANCER_ADDRESS=$_LOAD_BALANCER_ADDRESS
+        OAUTH_CLIENT_NAME=$(cat /workspace/oauth_client_name)
+	      export INT_OAUTH_CLIENT_ID=${OAUTH_CLIENT_NAME##*/}
         make integration-test-cloudbuild
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -86,7 +86,6 @@ steps:
     args:
       - '-c'
       - |
-        export INT_API_URL=$_API_URL
         export INT_DATASET_BUCKET_NAME=$_DATASET_BUCKET_NAME
         export INT_AUTODELETE_DATASET_BUCKET_FILE=$_AUTODELETE_DATASET_BUCKET_FILE
         export INT_LOG_LEVEL=$_LOG_LEVEL
@@ -94,7 +93,7 @@ steps:
         export INT_SCHEMA_BUCKET_NAME=$_SCHEMA_BUCKET_NAME
         export INT_PUBLISH_SCHEMA_TOPIC_ID=$_PUBLISH_SCHEMA_TOPIC_ID
         export INT_PUBLISH_DATASET_TOPIC_ID=$_PUBLISH_DATASET_TOPIC_ID
-        export INT_LOAD_BALANCER_ADDRESS=$_LOAD_BALANCER_ADDRESS
+        export INT_API_URL=$_API_URL
         OAUTH_CLIENT_NAME=$(cat /workspace/oauth_client_name)
         export INT_OAUTH_CLIENT_ID=${OAUTH_CLIENT_NAME##*/}
         make integration-test-cloudbuild

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -85,7 +85,7 @@ steps:
         export INT_PUBLISH_DATASET_TOPIC_ID=$_PUBLISH_DATASET_TOPIC_ID
         export INT_LOAD_BALANCER_ADDRESS=$_LOAD_BALANCER_ADDRESS
         OAUTH_CLIENT_NAME=$(cat /workspace/oauth_client_name)
-	      export INT_OAUTH_CLIENT_ID=${OAUTH_CLIENT_NAME##*/}
+        export INT_OAUTH_CLIENT_ID=${OAUTH_CLIENT_NAME##*/}
         make integration-test-cloudbuild
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -43,7 +43,7 @@ steps:
     id: "Run image"
     entrypoint: gcloud
     args: [ 'run', 'deploy', 'sds', '--image', 'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:$SHORT_SHA',
-            '--region', 'europe-west2' ]
+            '--region', 'europe-west2', '--allow-unauthenticated', '--ingress', 'internal-and-cloud-load-balancing' ]
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: "Deploy cloud function"
     entrypoint: sh
@@ -52,7 +52,9 @@ steps:
       - |
         cd src/app/
         gcloud functions deploy new-dataset-function \
+        --allow-unauthenticated \
         --gen2 \
+        --ingress-settings=internal-and-gclb \
         --runtime=python311 \
         --region=europe-west2 \
         --source=. \
@@ -84,7 +86,6 @@ steps:
     args:
       - '-c'
       - |
-        export ACCESS_TOKEN=$(cat /workspace/token)
         export INT_API_URL=$_API_URL
         export INT_DATASET_BUCKET_NAME=$_DATASET_BUCKET_NAME
         export INT_AUTODELETE_DATASET_BUCKET_FILE=$_AUTODELETE_DATASET_BUCKET_FILE

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -61,13 +61,23 @@ steps:
         --trigger-event-filters="bucket=${_DATASET_BUCKET_NAME}" \
         --set-env-vars="DATASET_BUCKET_NAME=${_DATASET_BUCKET_NAME},SCHEMA_BUCKET_NAME=${_SCHEMA_BUCKET_NAME},CONF=cloud-build,AUTODELETE_DATASET_BUCKET_FILE=${_AUTODELETE_DATASET_BUCKET_FILE},LOG_LEVEL=${_LOG_LEVEL},PROJECT_ID=${_PROJECT_ID},PUBLISH_SCHEMA_TOPIC_ID=${_PUBLISH_SCHEMA_TOPIC_ID},PUBLISH_DATASET_TOPIC_ID=${_PUBLISH_DATASET_TOPIC_ID}"
   - name: 'gcr.io/cloud-builders/gcloud'
-    id: "Get token"
+    id: 'Get api gateway hostname'
+    id: 'Retrieve `OAUTH_BRAND_NAME` and save it to workspace'
     entrypoint: sh
     args:
       - '-c'
       - |
-        gcloud auth print-identity-token --impersonate-service-account=${_CLOUDBUILD_SA} > /workspace/token
-        curl -H "Authorization: Bearer $(cat /workspace/token)" ${_API_URL}/docs
+        gcloud iap oauth-brands list --format='value(name)' --limit=1 --project=${PROJECT_ID} \
+        > /workspace/oauth_brand_name
+  - name: 'gcr.io/cloud-builders/gcloud'
+    id: 'Retrieve `OAUTH_CLIENT_NAME` and save it to workspace'
+    entrypoint: sh
+    args:
+      - '-c'
+      - |
+        gcloud iap oauth-clients list $(cat /workspace/oauth_brand_name) --format='value(name)' \
+        --limit=1 \
+        > /workspace/oauth_client_name
   - name: python
     id: "Run integration test"
     entrypoint: sh

--- a/src/app/config/config.py
+++ b/src/app/config/config.py
@@ -51,8 +51,8 @@ class IntegrationTestConfig(BaseSettings):
         self.PROJECT_ID = get_value_from_env("PROJECT_ID")
         self.PUBLISH_SCHEMA_TOPIC_ID = get_value_from_env("PUBLISH_SCHEMA_TOPIC_ID")
         self.PUBLISH_DATASET_TOPIC_ID = get_value_from_env("PUBLISH_DATASET_TOPIC_ID")
-        self.LOAD_BALANCER_ADDRESS = get_value_from_env(
-            "LOAD_BALANCER_ADDRESS", "localhost"
+        self.API_URL = get_value_from_env(
+            "API_URL", "localhost"
         )
         self.OAUTH_CLIENT_ID = get_value_from_env("OAUTH_CLIENT_ID", "localhost")
 
@@ -66,7 +66,7 @@ class IntegrationTestConfig(BaseSettings):
     PROJECT_ID: str
     PUBLISH_SCHEMA_TOPIC_ID: str
     PUBLISH_DATASET_TOPIC_ID: str
-    LOAD_BALANCER_ADDRESS: str
+    API_URL: str
     OAUTH_CLIENT_ID: str
 
 
@@ -90,8 +90,8 @@ class IntegrationTestCloudbuildConfig(BaseSettings):
         self.PROJECT_ID = get_value_from_env("PROJECT_ID")
         self.PUBLISH_SCHEMA_TOPIC_ID = get_value_from_env("PUBLISH_SCHEMA_TOPIC_ID")
         self.PUBLISH_DATASET_TOPIC_ID = get_value_from_env("PUBLISH_DATASET_TOPIC_ID")
-        self.LOAD_BALANCER_ADDRESS = get_value_from_env(
-            "LOAD_BALANCER_ADDRESS", "localhost"
+        self.API_URL = get_value_from_env(
+            "API_URL", "localhost"
         )
         self.OAUTH_CLIENT_ID = get_value_from_env("OAUTH_CLIENT_ID", "localhost")
 
@@ -104,7 +104,7 @@ class IntegrationTestCloudbuildConfig(BaseSettings):
     PROJECT_ID: str
     PUBLISH_SCHEMA_TOPIC_ID: str
     PUBLISH_DATASET_TOPIC_ID: str
-    LOAD_BALANCER_ADDRESS: str
+    API_URL: str
     OAUTH_CLIENT_ID: str
 
 

--- a/src/app/config/config.py
+++ b/src/app/config/config.py
@@ -33,7 +33,6 @@ class IntegrationTestConfig(BaseSettings):
         super().__init__()
         self.CONF = get_value_from_env("CONF")
         self.TIME_FORMAT = TIME_FORMAT_STRING
-        self.API_URL = get_value_from_env("API_URL", "localhost")
         self.DATASET_BUCKET_NAME = get_value_from_env(
             "DATASET_BUCKET_NAME", "test_dataset_bucket"
         )
@@ -63,7 +62,6 @@ class IntegrationTestConfig(BaseSettings):
     SCHEMA_BUCKET_NAME: str
     TEST_DATASET_PATH: str
     TEST_SCHEMA_PATH: str
-    API_URL: str
     GOOGLE_APPLICATION_CREDENTIALS: str
     PROJECT_ID: str
     PUBLISH_SCHEMA_TOPIC_ID: str
@@ -77,7 +75,6 @@ class IntegrationTestCloudbuildConfig(BaseSettings):
         super().__init__()
         self.CONF = get_value_from_env("CONF")
         self.TIME_FORMAT = TIME_FORMAT_STRING
-        self.API_URL = get_value_from_env("API_URL", "localhost")
         self.DATASET_BUCKET_NAME = get_value_from_env(
             "DATASET_BUCKET_NAME", "testDatasetBucket"
         )
@@ -90,7 +87,6 @@ class IntegrationTestCloudbuildConfig(BaseSettings):
         self.TEST_SCHEMA_PATH = get_value_from_env(
             "TEST_SCHEMA_PATH", "src/test_data/schema.json"
         )
-        self.ACCESS_TOKEN = get_value_from_env("ACCESS_TOKEN")
         self.PROJECT_ID = get_value_from_env("PROJECT_ID")
         self.PUBLISH_SCHEMA_TOPIC_ID = get_value_from_env("PUBLISH_SCHEMA_TOPIC_ID")
         self.PUBLISH_DATASET_TOPIC_ID = get_value_from_env("PUBLISH_DATASET_TOPIC_ID")
@@ -105,8 +101,6 @@ class IntegrationTestCloudbuildConfig(BaseSettings):
     SCHEMA_BUCKET_NAME: str
     TEST_DATASET_PATH: str
     TEST_SCHEMA_PATH: str
-    API_URL: str
-    ACCESS_TOKEN: str
     PROJECT_ID: str
     PUBLISH_SCHEMA_TOPIC_ID: str
     PUBLISH_DATASET_TOPIC_ID: str

--- a/src/app/config/config.py
+++ b/src/app/config/config.py
@@ -52,6 +52,10 @@ class IntegrationTestConfig(BaseSettings):
         self.PROJECT_ID = get_value_from_env("PROJECT_ID")
         self.PUBLISH_SCHEMA_TOPIC_ID = get_value_from_env("PUBLISH_SCHEMA_TOPIC_ID")
         self.PUBLISH_DATASET_TOPIC_ID = get_value_from_env("PUBLISH_DATASET_TOPIC_ID")
+        self.LOAD_BALANCER_ADDRESS = get_value_from_env(
+            "LOAD_BALANCER_ADDRESS", "localhost"
+        )
+        self.OAUTH_CLIENT_ID = get_value_from_env("OAUTH_CLIENT_ID", "localhost")
 
     CONF: str
     TIME_FORMAT: str = TIME_FORMAT_STRING
@@ -64,6 +68,8 @@ class IntegrationTestConfig(BaseSettings):
     PROJECT_ID: str
     PUBLISH_SCHEMA_TOPIC_ID: str
     PUBLISH_DATASET_TOPIC_ID: str
+    LOAD_BALANCER_ADDRESS: str
+    OAUTH_CLIENT_ID: str
 
 
 class IntegrationTestCloudbuildConfig(BaseSettings):
@@ -88,6 +94,10 @@ class IntegrationTestCloudbuildConfig(BaseSettings):
         self.PROJECT_ID = get_value_from_env("PROJECT_ID")
         self.PUBLISH_SCHEMA_TOPIC_ID = get_value_from_env("PUBLISH_SCHEMA_TOPIC_ID")
         self.PUBLISH_DATASET_TOPIC_ID = get_value_from_env("PUBLISH_DATASET_TOPIC_ID")
+        self.LOAD_BALANCER_ADDRESS = get_value_from_env(
+            "LOAD_BALANCER_ADDRESS", "localhost"
+        )
+        self.OAUTH_CLIENT_ID = get_value_from_env("OAUTH_CLIENT_ID", "localhost")
 
     CONF: str
     TIME_FORMAT: str = TIME_FORMAT_STRING
@@ -100,6 +110,8 @@ class IntegrationTestCloudbuildConfig(BaseSettings):
     PROJECT_ID: str
     PUBLISH_SCHEMA_TOPIC_ID: str
     PUBLISH_DATASET_TOPIC_ID: str
+    LOAD_BALANCER_ADDRESS: str
+    OAUTH_CLIENT_ID: str
 
 
 class CloudBuildConfig(BaseSettings):

--- a/src/app/config/config.py
+++ b/src/app/config/config.py
@@ -51,9 +51,7 @@ class IntegrationTestConfig(BaseSettings):
         self.PROJECT_ID = get_value_from_env("PROJECT_ID")
         self.PUBLISH_SCHEMA_TOPIC_ID = get_value_from_env("PUBLISH_SCHEMA_TOPIC_ID")
         self.PUBLISH_DATASET_TOPIC_ID = get_value_from_env("PUBLISH_DATASET_TOPIC_ID")
-        self.API_URL = get_value_from_env(
-            "API_URL", "localhost"
-        )
+        self.API_URL = get_value_from_env("API_URL", "localhost")
         self.OAUTH_CLIENT_ID = get_value_from_env("OAUTH_CLIENT_ID", "localhost")
 
     CONF: str
@@ -90,9 +88,7 @@ class IntegrationTestCloudbuildConfig(BaseSettings):
         self.PROJECT_ID = get_value_from_env("PROJECT_ID")
         self.PUBLISH_SCHEMA_TOPIC_ID = get_value_from_env("PUBLISH_SCHEMA_TOPIC_ID")
         self.PUBLISH_DATASET_TOPIC_ID = get_value_from_env("PUBLISH_DATASET_TOPIC_ID")
-        self.API_URL = get_value_from_env(
-            "API_URL", "localhost"
-        )
+        self.API_URL = get_value_from_env("API_URL", "localhost")
         self.OAUTH_CLIENT_ID = get_value_from_env("OAUTH_CLIENT_ID", "localhost")
 
     CONF: str

--- a/src/integration_tests/datasets/e2e_dataset_integration_test.py
+++ b/src/integration_tests/datasets/e2e_dataset_integration_test.py
@@ -53,7 +53,7 @@ class E2ESchemaIntegrationTest(TestCase):
         )
 
         dataset_metadata_response = session.get(
-            f"{config.API_URL}/v1/dataset_metadata?survey_id={dataset['survey_id']}&period_id={dataset['period_id']}",
+            f"{config.LOAD_BALANCER_ADDRESS}/v1/dataset_metadata?survey_id={dataset['survey_id']}&period_id={dataset['period_id']}",
             headers=headers,
         )
         assert dataset_metadata_response.status_code == 200
@@ -62,7 +62,7 @@ class E2ESchemaIntegrationTest(TestCase):
             if dataset_metadata["filename"] == filename:
                 dataset_id = dataset_metadata["dataset_id"]
                 response = session.get(
-                    f"{config.API_URL}/v1/unit_data?dataset_id={dataset_id}&unit_id={unit_id}",
+                    f"{config.LOAD_BALANCER_ADDRESS}/v1/unit_data?dataset_id={dataset_id}&unit_id={unit_id}",
                     headers=headers,
                 )
 

--- a/src/integration_tests/datasets/e2e_dataset_integration_test.py
+++ b/src/integration_tests/datasets/e2e_dataset_integration_test.py
@@ -53,7 +53,8 @@ class E2ESchemaIntegrationTest(TestCase):
         )
 
         dataset_metadata_response = session.get(
-            f"{config.LOAD_BALANCER_ADDRESS}/v1/dataset_metadata?survey_id={dataset['survey_id']}&period_id={dataset['period_id']}",
+            f"{config.LOAD_BALANCER_ADDRESS}/v1/dataset_metadata?"
+            f"survey_id={dataset['survey_id']}&period_id={dataset['period_id']}",
             headers=headers,
         )
         assert dataset_metadata_response.status_code == 200

--- a/src/integration_tests/datasets/e2e_dataset_integration_test.py
+++ b/src/integration_tests/datasets/e2e_dataset_integration_test.py
@@ -53,7 +53,7 @@ class E2ESchemaIntegrationTest(TestCase):
         )
 
         dataset_metadata_response = session.get(
-            f"{config.LOAD_BALANCER_ADDRESS}/v1/dataset_metadata?"
+            f"{config.API_URL}/v1/dataset_metadata?"
             f"survey_id={dataset['survey_id']}&period_id={dataset['period_id']}",
             headers=headers,
         )
@@ -63,7 +63,7 @@ class E2ESchemaIntegrationTest(TestCase):
             if dataset_metadata["filename"] == filename:
                 dataset_id = dataset_metadata["dataset_id"]
                 response = session.get(
-                    f"{config.LOAD_BALANCER_ADDRESS}/v1/unit_data?dataset_id={dataset_id}&unit_id={unit_id}",
+                    f"{config.API_URL}/v1/unit_data?dataset_id={dataset_id}&unit_id={unit_id}",
                     headers=headers,
                 )
 

--- a/src/integration_tests/helpers/integration_helpers.py
+++ b/src/integration_tests/helpers/integration_helpers.py
@@ -95,7 +95,7 @@ def create_dataset(
     Returns:
         int | None: status code for local function and no return for remote.
     """
-    if config.API_URL.__contains__("local"):
+    if config.OAUTH_CLIENT_ID.__contains__("local"):
         return _create_local_dataset(session, dataset)
     else:
         _create_remote_dataset(session, filename, dataset, headers)
@@ -167,7 +167,7 @@ def wait_until_dataset_ready(
     """
     while attempts != 0:
         test_response = session.get(
-            f"{config.API_URL}/v1/dataset_metadata?survey_id={survey_id}&period_id={period_id}",
+            f"{config.LOAD_BALANCER_ADDRESS}/v1/dataset_metadata?survey_id={survey_id}&period_id={period_id}",
             headers=headers,
         )
 
@@ -190,7 +190,7 @@ def cleanup() -> None:
     Returns:
         None
     """
-    if config.API_URL.__contains__("local"):
+    if config.OAUTH_CLIENT_ID.__contains__("local"):
         delete_local_firestore_data()
 
         delete_local_bucket_data("devtools/gcp-storage-emulator/data/schema_bucket/")

--- a/src/integration_tests/helpers/integration_helpers.py
+++ b/src/integration_tests/helpers/integration_helpers.py
@@ -53,7 +53,7 @@ def generate_headers() -> dict[str, str]:
         dict[str, str]: the headers required for remote authentication.
     """
     headers = {}
-    
+
     auth_req = google.auth.transport.requests.Request()
     auth_token = google.oauth2.id_token.fetch_id_token(
         auth_req, audience=config.OAUTH_CLIENT_ID

--- a/src/integration_tests/helpers/integration_helpers.py
+++ b/src/integration_tests/helpers/integration_helpers.py
@@ -167,7 +167,7 @@ def wait_until_dataset_ready(
     """
     while attempts != 0:
         test_response = session.get(
-            f"{config.LOAD_BALANCER_ADDRESS}/v1/dataset_metadata?survey_id={survey_id}&period_id={period_id}",
+            f"{config.API_URL}/v1/dataset_metadata?survey_id={survey_id}&period_id={period_id}",
             headers=headers,
         )
 

--- a/src/integration_tests/helpers/integration_helpers.py
+++ b/src/integration_tests/helpers/integration_helpers.py
@@ -6,9 +6,11 @@ import google.oauth2.id_token
 import requests
 from config.config_factory import config
 from google.cloud import storage
+from oauthlib.oauth2 import MobileApplicationClient
 from repositories.buckets.bucket_loader import bucket_loader
 from repositories.firebase.firebase_loader import firebase_loader
 from requests.adapters import HTTPAdapter
+from requests_oauthlib import OAuth2Session
 from urllib3 import Retry
 
 from src.integration_tests.helpers.bucket_helpers import (
@@ -56,9 +58,14 @@ def generate_headers() -> dict[str, str]:
     auth_token = os.environ.get("ACCESS_TOKEN")
     if auth_token is None:
         auth_req = google.auth.transport.requests.Request()
-        auth_token = google.oauth2.id_token.fetch_id_token(auth_req, config.API_URL)
+        auth_token = google.oauth2.id_token.fetch_id_token(
+            auth_req, audience=config.OAUTH_CLIENT_ID
+        )
 
-    headers = {"Authorization": f"Bearer {auth_token}"}
+    headers = {
+        "Authorization": f"Bearer {auth_token}",
+        "Content-Type": "application/json",
+    }
 
     return headers
 

--- a/src/integration_tests/helpers/integration_helpers.py
+++ b/src/integration_tests/helpers/integration_helpers.py
@@ -6,11 +6,9 @@ import google.oauth2.id_token
 import requests
 from config.config_factory import config
 from google.cloud import storage
-from oauthlib.oauth2 import MobileApplicationClient
 from repositories.buckets.bucket_loader import bucket_loader
 from repositories.firebase.firebase_loader import firebase_loader
 from requests.adapters import HTTPAdapter
-from requests_oauthlib import OAuth2Session
 from urllib3 import Retry
 
 from src.integration_tests.helpers.bucket_helpers import (

--- a/src/integration_tests/helpers/integration_helpers.py
+++ b/src/integration_tests/helpers/integration_helpers.py
@@ -1,5 +1,4 @@
 import json
-import os
 import time
 
 import google.oauth2.id_token

--- a/src/integration_tests/helpers/integration_helpers.py
+++ b/src/integration_tests/helpers/integration_helpers.py
@@ -53,12 +53,11 @@ def generate_headers() -> dict[str, str]:
         dict[str, str]: the headers required for remote authentication.
     """
     headers = {}
-    auth_token = os.environ.get("ACCESS_TOKEN")
-    if auth_token is None:
-        auth_req = google.auth.transport.requests.Request()
-        auth_token = google.oauth2.id_token.fetch_id_token(
-            auth_req, audience=config.OAUTH_CLIENT_ID
-        )
+    
+    auth_req = google.auth.transport.requests.Request()
+    auth_token = google.oauth2.id_token.fetch_id_token(
+        auth_req, audience=config.OAUTH_CLIENT_ID
+    )
 
     headers = {
         "Authorization": f"Bearer {auth_token}",

--- a/src/integration_tests/helpers/pubsub_helper.py
+++ b/src/integration_tests/helpers/pubsub_helper.py
@@ -12,13 +12,13 @@ from src.test_data.shared_test_data import (
 
 class PubSubHelper:
     def __init__(self, topic_id: str, subscriber_id: str):
-        if config.API_URL.__contains__("local"):
+        if config.OAUTH_CLIENT_ID.__contains__("local"):
             os.environ["PUBSUB_EMULATOR_HOST"] = "localhost:8085"
 
         self.subscriber_client = pubsub_v1.SubscriberClient()
         self.publisher_client = pubsub_v1.PublisherClient()
 
-        if config.API_URL.__contains__("local"):
+        if config.OAUTH_CLIENT_ID.__contains__("local"):
             self._try_create_topic(topic_id)
 
         self._try_create_subscriber(topic_id, subscriber_id)

--- a/src/integration_tests/schemas/e2e_schema_integration_test.py
+++ b/src/integration_tests/schemas/e2e_schema_integration_test.py
@@ -64,7 +64,8 @@ class E2ESchemaIntegrationTest(TestCase):
             }
 
             set_version_schema_response = session.get(
-                f"{config.LOAD_BALANCER_ADDRESS}/v1/schema?survey_id={schema['survey_id']}&version={schema['sds_schema_version']}",
+                f"{config.LOAD_BALANCER_ADDRESS}/v1/schema?"
+                f"survey_id={schema['survey_id']}&version={schema['sds_schema_version']}",
                 headers=headers,
             )
 

--- a/src/integration_tests/schemas/e2e_schema_integration_test.py
+++ b/src/integration_tests/schemas/e2e_schema_integration_test.py
@@ -29,9 +29,11 @@ class E2ESchemaIntegrationTest(TestCase):
         test_schema = load_json(config.TEST_SCHEMA_PATH)
 
         schema_post_response = session.post(
-            f"{config.API_URL}/v1/schema", json=test_schema, headers=headers
+            f"{config.LOAD_BALANCER_ADDRESS}/v1/schema",
+            json=test_schema,
+            headers=headers,
         )
-
+        print(schema_post_response.content)
         assert schema_post_response.status_code == 200
         assert "guid" in schema_post_response.json()
 
@@ -43,7 +45,7 @@ class E2ESchemaIntegrationTest(TestCase):
         assert received_messages_json == schema_post_response.json()
 
         test_schema_get_response = session.get(
-            f"{config.API_URL}/v1/schema_metadata?survey_id={test_schema['survey_id']}",
+            f"{config.LOAD_BALANCER_ADDRESS}/v1/schema_metadata?survey_id={test_schema['survey_id']}",
             headers=headers,
         )
 
@@ -62,7 +64,7 @@ class E2ESchemaIntegrationTest(TestCase):
             }
 
             set_version_schema_response = session.get(
-                f"{config.API_URL}/v1/schema?survey_id={schema['survey_id']}&version={schema['sds_schema_version']}",
+                f"{config.LOAD_BALANCER_ADDRESS}/v1/schema?survey_id={schema['survey_id']}&version={schema['sds_schema_version']}",
                 headers=headers,
             )
 
@@ -70,7 +72,7 @@ class E2ESchemaIntegrationTest(TestCase):
             assert set_version_schema_response.json() == test_schema
 
             latest_version_schema_response = session.get(
-                f"{config.API_URL}/v1/schema?survey_id={schema['survey_id']}",
+                f"{config.LOAD_BALANCER_ADDRESS}/v1/schema?survey_id={schema['survey_id']}",
                 headers=headers,
             )
 

--- a/src/integration_tests/schemas/e2e_schema_integration_test.py
+++ b/src/integration_tests/schemas/e2e_schema_integration_test.py
@@ -29,7 +29,7 @@ class E2ESchemaIntegrationTest(TestCase):
         test_schema = load_json(config.TEST_SCHEMA_PATH)
 
         schema_post_response = session.post(
-            f"{config.LOAD_BALANCER_ADDRESS}/v1/schema",
+            f"{config.API_URL}/v1/schema",
             json=test_schema,
             headers=headers,
         )
@@ -45,7 +45,7 @@ class E2ESchemaIntegrationTest(TestCase):
         assert received_messages_json == schema_post_response.json()
 
         test_schema_get_response = session.get(
-            f"{config.LOAD_BALANCER_ADDRESS}/v1/schema_metadata?survey_id={test_schema['survey_id']}",
+            f"{config.API_URL}/v1/schema_metadata?survey_id={test_schema['survey_id']}",
             headers=headers,
         )
 
@@ -64,7 +64,7 @@ class E2ESchemaIntegrationTest(TestCase):
             }
 
             set_version_schema_response = session.get(
-                f"{config.LOAD_BALANCER_ADDRESS}/v1/schema?"
+                f"{config.API_URL}/v1/schema?"
                 f"survey_id={schema['survey_id']}&version={schema['sds_schema_version']}",
                 headers=headers,
             )
@@ -73,7 +73,7 @@ class E2ESchemaIntegrationTest(TestCase):
             assert set_version_schema_response.json() == test_schema
 
             latest_version_schema_response = session.get(
-                f"{config.LOAD_BALANCER_ADDRESS}/v1/schema?survey_id={schema['survey_id']}",
+                f"{config.API_URL}/v1/schema?survey_id={schema['survey_id']}",
                 headers=headers,
             )
 

--- a/src/integration_tests/schemas/e2e_schema_integration_test.py
+++ b/src/integration_tests/schemas/e2e_schema_integration_test.py
@@ -33,7 +33,7 @@ class E2ESchemaIntegrationTest(TestCase):
             json=test_schema,
             headers=headers,
         )
-        print(schema_post_response.content)
+
         assert schema_post_response.status_code == 200
         assert "guid" in schema_post_response.json()
 

--- a/src/unit_tests/config/config_factory_test.py
+++ b/src/unit_tests/config/config_factory_test.py
@@ -31,7 +31,7 @@ class ConfigFactoryTest(TestCase):
         os.environ["STORAGE_EMULATOR_HOST"] = testConfigVars.storage_host
         os.environ["PUBSUB_EMULATOR_HOST"] = testConfigVars.pubsub_emulator_host
         os.environ["SCHEMA_BUCKET_NAME"] = testConfigVars.schema_bucket_name
-        os.environ["LOAD_BALANCER_ADDRESS"] = testConfigVars.load_balancer_address
+        os.environ["API_URL"] = testConfigVars.api_url
         os.environ["OAUTH_CLIENT_ID"] = testConfigVars.oauth_client_id
 
     def tearDown(self):
@@ -43,7 +43,7 @@ class ConfigFactoryTest(TestCase):
         os.environ["FIRESTORE_EMULATOR_HOST"] = ""
         os.environ["STORAGE_EMULATOR_HOST"] = ""
         os.environ["SCHEMA_BUCKET_NAME"] = ""
-        os.environ["LOAD_BALANCER_ADDRESS"] = ""
+        os.environ["API_URL"] = ""
         os.environ["OAUTH_CLIENT_ID"] = ""
 
     def test_docker_dev_factory(self):

--- a/src/unit_tests/config/config_factory_test.py
+++ b/src/unit_tests/config/config_factory_test.py
@@ -33,6 +33,8 @@ class ConfigFactoryTest(TestCase):
         os.environ["SCHEMA_BUCKET_NAME"] = testConfigVars.schema_bucket_name
         os.environ["API_URL"] = testConfigVars.api_url
         os.environ["ACCESS_TOKEN"] = testConfigVars.access_token
+        os.environ["LOAD_BALANCER_ADDRESS"] = testConfigVars.load_balancer_address
+        os.environ["OAUTH_CLIENT_ID"] = testConfigVars.oauth_client_id
 
     def tearDown(self):
         os.environ["CONF"] = INITIAL_CONF
@@ -45,6 +47,8 @@ class ConfigFactoryTest(TestCase):
         os.environ["SCHEMA_BUCKET_NAME"] = ""
         os.environ["API_URL"] = ""
         os.environ["ACCESS_TOKEN"] = ""
+        os.environ["LOAD_BALANCER_ADDRESS"] = ""
+        os.environ["OAUTH_CLIENT_ID"] = ""
 
     def test_docker_dev_factory(self):
         os.environ["CONF"] = "docker-dev"

--- a/src/unit_tests/config/config_factory_test.py
+++ b/src/unit_tests/config/config_factory_test.py
@@ -31,8 +31,6 @@ class ConfigFactoryTest(TestCase):
         os.environ["STORAGE_EMULATOR_HOST"] = testConfigVars.storage_host
         os.environ["PUBSUB_EMULATOR_HOST"] = testConfigVars.pubsub_emulator_host
         os.environ["SCHEMA_BUCKET_NAME"] = testConfigVars.schema_bucket_name
-        os.environ["API_URL"] = testConfigVars.api_url
-        os.environ["ACCESS_TOKEN"] = testConfigVars.access_token
         os.environ["LOAD_BALANCER_ADDRESS"] = testConfigVars.load_balancer_address
         os.environ["OAUTH_CLIENT_ID"] = testConfigVars.oauth_client_id
 
@@ -45,8 +43,6 @@ class ConfigFactoryTest(TestCase):
         os.environ["FIRESTORE_EMULATOR_HOST"] = ""
         os.environ["STORAGE_EMULATOR_HOST"] = ""
         os.environ["SCHEMA_BUCKET_NAME"] = ""
-        os.environ["API_URL"] = ""
-        os.environ["ACCESS_TOKEN"] = ""
         os.environ["LOAD_BALANCER_ADDRESS"] = ""
         os.environ["OAUTH_CLIENT_ID"] = ""
 

--- a/src/unit_tests/config/config_test.py
+++ b/src/unit_tests/config/config_test.py
@@ -14,8 +14,6 @@ class testConfigVars:
     app_credentials = "test_app_credentials"
     dataset_path = "test_dataset_path"
     schema_path = "test_schema_path"
-    api_url = "test_API_url"
-    access_token = "test_access_token"
     load_balancer_address = "test_load_balancer_address"
     oauth_client_id = "test_oauth_client_id"
 
@@ -198,7 +196,6 @@ class ConfigTest(TestCase):
         os.environ["SCHEMA_BUCKET_NAME"] = testConfigVars.schema_bucket_name
         os.environ["TEST_DATASET_PATH"] = testConfigVars.dataset_path
         os.environ["TEST_SCHEMA_PATH"] = testConfigVars.schema_path
-        os.environ["ACCESS_TOKEN"] = testConfigVars.access_token
 
         testConfig = config.IntegrationTestCloudbuildConfig()
 
@@ -209,5 +206,4 @@ class ConfigTest(TestCase):
             and testConfig.TEST_DATASET_PATH == testConfigVars.dataset_path
             and testConfig.TEST_SCHEMA_PATH == testConfigVars.schema_path
             and testConfig.SCHEMA_BUCKET_NAME == testConfigVars.schema_bucket_name
-            and testConfig.ACCESS_TOKEN == testConfigVars.access_token
         )

--- a/src/unit_tests/config/config_test.py
+++ b/src/unit_tests/config/config_test.py
@@ -14,7 +14,7 @@ class testConfigVars:
     app_credentials = "test_app_credentials"
     dataset_path = "test_dataset_path"
     schema_path = "test_schema_path"
-    load_balancer_address = "test_load_balancer_address"
+    api_url = "test_api_url"
     oauth_client_id = "test_oauth_client_id"
 
 

--- a/src/unit_tests/config/config_test.py
+++ b/src/unit_tests/config/config_test.py
@@ -16,6 +16,8 @@ class testConfigVars:
     schema_path = "test_schema_path"
     api_url = "test_API_url"
     access_token = "test_access_token"
+    load_balancer_address = "test_load_balancer_address"
+    oauth_client_id = "test_oauth_client_id"
 
 
 class ConfigTest(TestCase):


### PR DESCRIPTION
### Motivation and Context
Adjust to access cloud service through IAP enabled load balancer in the lower region

### What has changed
- Remote integration test now use a static load balancer ip and an OAuth client id to access the cloud service
- Cloudbuild integration test now fetch the OAuth client id from GCP using gcloud and use it to get access to the cloud service
- Remove obsolete environment variables

### How to test?
Pass unit test, local and remote integration test
Successfully go through all the steps in cloudbuild trigger, including the cloudbuild integration test

### Links
https://jira.ons.gov.uk/browse/SDSS-115
