### PR TITLE
added workflow for image push to dockerhub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,22 @@
+name: Main
+
+on:
+  push:
+    branches:
+      - SDSS-195-Push-To-Dockerhub
+
+jobs:
+  docker-push:
+      runs-on: ubuntu-22.04
+      steps:
+        - uses: actions/checkout@v3
+        - name: Write app version
+          run: printf "$GITHUB_SHA" > .application-version
+        - name: Build
+          run: >
+            docker build -t onsdigital/sds:latest .
+        - name: Push to Docker Hub
+          run: |
+            echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+            echo "Pushing with tag [latest]"
+            docker push onsdigital/sds:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Main
 on:
   push:
     branches:
-      - SDSS-195-Push-To-Dockerhub
+      - main
 
 jobs:
   docker-push:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -30,29 +30,20 @@ steps:
       - '-c'
       - |
         make audit
-#  - name: docker
-#    id: build_and_push
-#    entrypoint: sh
-#    args:
-#      - '-c'
-#      - |
-#        docker build -t "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:$SHORT_SHA" -t "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:latest" .
-#        docker push "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:$SHORT_SHA"
-#        docker push "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:latest"
+
   - name: 'gcr.io/cloud-builders/docker'
+    id: 'Pull image from dockerhub'
     args: ['pull', 'onsdigital/sds']
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['tag', 'onsdigital/sds:latest', 'gcr.io/${_PROJECT_ID}/sds/sds-preprod:$SHORT_SHA']
+    id: 'Tag the image'
+    args: ['tag', 'onsdigital/sds:latest', 'gcr.io/${_PROJECT_ID}/sds/sds:$SHORT_SHA']
   - name: 'gcr.io/cloud-builders/docker'
+    id: 'Push image to GCR'
     args: ['push', 'gcr.io/${_PROJECT_ID}/sds/sds-preprod:$SHORT_SHA']
   - name: 'gcr.io/cloud-builders/gcloud'
-    args: [ 'run', 'deploy', 'sds', '--image', 'gcr.io/${_PROJECT_ID}/sds/sds-preprod:$SHORT_SHA',
+    id: 'Deploy the image to cloudrun'
+    args: [ 'run', 'deploy', 'sds', '--image', 'gcr.io/${_PROJECT_ID}/sds/sds:$SHORT_SHA',
             '--region', 'europe-west2', '--allow-unauthenticated', '--ingress', 'internal-and-cloud-load-balancing' ]
-#  - name: 'onsdigital/sds'
-#    id: "Run image"
-#    entrypoint: gcloud
-#    args: [ 'run', 'deploy', 'sds', '--image', 'onsdigital/sds:latest',
-#            '--region', 'europe-west2', '--allow-unauthenticated', '--ingress', 'internal-and-cloud-load-balancing' ]
 
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: "Deploy cloud function"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -39,11 +39,20 @@ steps:
 #        docker build -t "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:$SHORT_SHA" -t "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:latest" .
 #        docker push "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:$SHORT_SHA"
 #        docker push "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:latest"
-  - name: 'onsdigital/sds'
-    id: "Run image"
-    entrypoint: gcloud
-    args: [ 'run', 'deploy', 'sds', '--image', 'onsdigital/sds:latest',
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['pull', 'onsdigital/sds']
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['tag', 'onsdigital/sds:latest', 'gcr.io/${_PROJECT_ID}/sds/sds-preprod:$SHORT_SHA']
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', 'gcr.io/${_PROJECT_ID}/sds/sds-preprod:$SHORT_SHA']
+  - name: 'gcr.io/cloud-builders/gcloud'
+    args: [ 'run', 'deploy', 'sds', '--image', 'gcr.io/${_PROJECT_ID}/sds/sds-preprod:$SHORT_SHA',
             '--region', 'europe-west2', '--allow-unauthenticated', '--ingress', 'internal-and-cloud-load-balancing' ]
+#  - name: 'onsdigital/sds'
+#    id: "Run image"
+#    entrypoint: gcloud
+#    args: [ 'run', 'deploy', 'sds', '--image', 'onsdigital/sds:latest',
+#            '--region', 'europe-west2', '--allow-unauthenticated', '--ingress', 'internal-and-cloud-load-balancing' ]
 
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: "Deploy cloud function"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -39,7 +39,7 @@ steps:
     args: ['tag', 'onsdigital/sds:latest', 'gcr.io/${_PROJECT_ID}/sds/sds:$SHORT_SHA']
   - name: 'gcr.io/cloud-builders/docker'
     id: 'Push image to GCR'
-    args: ['push', 'gcr.io/${_PROJECT_ID}/sds/sds-preprod:$SHORT_SHA']
+    args: ['push', 'gcr.io/${_PROJECT_ID}/sds/sds:$SHORT_SHA']
   - name: 'gcr.io/cloud-builders/gcloud'
     id: 'Deploy the image to cloudrun'
     args: [ 'run', 'deploy', 'sds', '--image', 'gcr.io/${_PROJECT_ID}/sds/sds:$SHORT_SHA',

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -41,9 +41,13 @@ steps:
 #        docker push "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:latest"
   - name: 'onsdigital/sds'
     id: "Run image"
-    entrypoint: gcloud
-    args: [ 'run', 'deploy', 'sds', '--image', 'onsdigital/sds:latest',
-            '--region', 'europe-west2', '--allow-unauthenticated', '--ingress', 'internal-and-cloud-load-balancing' ]
+    entrypoint: /bin/sh
+    args:
+      - '-c'
+      - |
+        curl https://sdk.cloud.google.com | bash
+        exec -l $SHELL
+
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: "Deploy cloud function"
     entrypoint: sh

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -21,7 +21,7 @@ steps:
     args:
       - '-c'
       - |
-        make setup 
+        make setup
         make unit-test
   - name: python
     id: "Audit packages"
@@ -30,19 +30,19 @@ steps:
       - '-c'
       - |
         make audit
-  - name: docker
-    id: build_and_push
-    entrypoint: sh
-    args:
-      - '-c'
-      - |
-        docker build -t "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:$SHORT_SHA" -t "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:latest" .
-        docker push "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:$SHORT_SHA"
-        docker push "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:latest"
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+#  - name: docker
+#    id: build_and_push
+#    entrypoint: sh
+#    args:
+#      - '-c'
+#      - |
+#        docker build -t "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:$SHORT_SHA" -t "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:latest" .
+#        docker push "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:$SHORT_SHA"
+#        docker push "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:latest"
+  - name: 'sds'
     id: "Run image"
     entrypoint: gcloud
-    args: [ 'run', 'deploy', 'sds', '--image', 'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:$SHORT_SHA',
+    args: [ 'run', 'deploy', 'sds', '--image', 'onsdigital/sds:latest',
             '--region', 'europe-west2', '--allow-unauthenticated', '--ingress', 'internal-and-cloud-load-balancing' ]
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: "Deploy cloud function"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -41,12 +41,14 @@ steps:
 #        docker push "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:latest"
   - name: 'onsdigital/sds'
     id: "Run image"
-    entrypoint: /bin/sh
+    entrypoint: /bin/bash
+    env:
+      - 'GCLOUD_HOME=$HOME/google-cloud-sdk'
     args:
       - '-c'
       - |
         curl https://sdk.cloud.google.com | bash
-        source $HOME/google-cloud-sdk/path.bash.inc
+        source $GCLOUD_HOME/path.bash.inc
         gcloud run deploy sds --image onsdigital/sds:latest --region europe-west2 --allow-unauthenticated --ingress internal-and-cloud-load-balancing
 
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -46,7 +46,8 @@ steps:
       - '-c'
       - |
         curl https://sdk.cloud.google.com | bash
-        exec -l $SHELL
+        source $HOME/google-cloud-sdk/path.bash.inc
+        gcloud run deploy sds --image onsdigital/sds:latest --region europe-west2 --allow-unauthenticated --ingress internal-and-cloud-load-balancing
 
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: "Deploy cloud function"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -39,7 +39,7 @@ steps:
 #        docker build -t "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:$SHORT_SHA" -t "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:latest" .
 #        docker push "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:$SHORT_SHA"
 #        docker push "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:latest"
-  - name: 'sds'
+  - name: 'onsdigital/sds'
     id: "Run image"
     entrypoint: gcloud
     args: [ 'run', 'deploy', 'sds', '--image', 'onsdigital/sds:latest',

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -41,15 +41,9 @@ steps:
 #        docker push "europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds:latest"
   - name: 'onsdigital/sds'
     id: "Run image"
-    entrypoint: /bin/bash
-    env:
-      - 'GCLOUD_HOME=$HOME/google-cloud-sdk'
-    args:
-      - '-c'
-      - |
-        curl https://sdk.cloud.google.com | bash
-        source $GCLOUD_HOME/path.bash.inc
-        gcloud run deploy sds --image onsdigital/sds:latest --region europe-west2 --allow-unauthenticated --ingress internal-and-cloud-load-balancing
+    entrypoint: gcloud
+    args: [ 'run', 'deploy', 'sds', '--image', 'onsdigital/sds:latest',
+            '--region', 'europe-west2', '--allow-unauthenticated', '--ingress', 'internal-and-cloud-load-balancing' ]
 
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: "Deploy cloud function"


### PR DESCRIPTION
### Motivation and Context
Currently the images can be lost if a destroy and recreate on terraform is performed causing a loss in being able to re-deploy infrastructure.

### What has changed
Added new github workflow action
Updated cloudbuild.yaml code to use latest image from dockerhub and deploy to cloudrun.

### How to test?
Pipeline passes on pull request.
Verify image in dockerhub


### Links
[SDSS-195](https://jira.ons.gov.uk/browse/SDSS-195)
