### PR TITLE
Sdss 186 guid schema endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,30 +175,16 @@ and SDS cloud function. The following sections describe a number of combinations
 
 ### Everything running in the cloud
 
-In this configuration, the SDS API service is running in Cloud Run and the new-dataset-function is deployed
-to Cloud Functions on your test/dev GCP project. These services both talk to Firestore and Cloud Storage running
-on the same project. This test configuration is also what is run at the end of the Cloud Build deployment.
-
-Run them like this (replacing `https://sds-blahblah.a.run.app` with the actual cloud run endpoint and
-`a-place-for-datasets` with the real dataset bucket):
+In this configuration, the integration test uses the SDS API service running in Cloud Run and the new-dataset-function
+on Cloud Functions of your test/dev GCP project. Please note that the SDS and cloud function are not the updated version unless
+run after creating a PR and gone through the pipeline. These services both talk to Firestore and Cloud Storage running on the same project. 
+This test configuration is also what is run at the end of the Cloud Build deployment.
 
 ```bash
 gcloud auth login
 gcloud config set project $PROJECT_NAME
  
-make cloud-test
-```
-
-### SDS API service is local
-
-This configuration allows you to debug the SDS API locally but talk to real Google services. Run them like this
-(replacing `my-schema-bucket` with the real schema bucket and `a-place-for-datasets` with the real dataset bucket):
-
-```bash
-gcloud auth login
-gcloud config set project $PROJECT_NAME
-
-make localSDS-test
+make integration-test-sandbox
 ```
 
 ### Running integration tests locally
@@ -209,7 +195,7 @@ is emulated by the test itself, or can be run manually by running the `SDX Simul
 ```bash
 docker-compose up
 
-make docker-test
+make integration-test-local
 ```
 
 # Contact

--- a/devtools/SDS - Local Docker.postman_collection.json
+++ b/devtools/SDS - Local Docker.postman_collection.json
@@ -107,6 +107,35 @@
 			"response": []
 		},
 		{
+			"name": "v2 Schema",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://127.0.0.1:3000/v2/schema?guid=a51a2d0f-8398-4b73-a4e7-528edd918a7f",
+					"protocol": "http",
+					"host": [
+						"127",
+						"0",
+						"0",
+						"1"
+					],
+					"port": "3000",
+					"path": [
+						"v2",
+						"schema"
+					],
+					"query": [
+						{
+							"key": "guid",
+							"value": "a51a2d0f-8398-4b73-a4e7-528edd918a7f"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "Simulate SDX Dataset Publish",
 			"request": {
 				"method": "POST",

--- a/gateway/openapi.yaml
+++ b/gateway/openapi.yaml
@@ -171,7 +171,7 @@ paths:
           schema:
             $ref: "#/definitions/sds_schema"
         400:
-          description: Invalid version provided
+          description: Incorrect key
           schema:
             type: object
             properties:
@@ -180,7 +180,7 @@ paths:
                 example: 400
               message:
                 type: string
-                example: Validation has failed
+                example: Invalid search provided
             required:
               - status
               - message
@@ -212,7 +212,63 @@ paths:
             required:
               - status
               - message
-
+              
+  /v2/schema:
+    get:
+      description: GET method that returns the schema corresponding to the given guid.
+      parameters:
+        - name: guid
+          in: query
+          type: string
+          required: true
+      responses:
+        200:
+          description: Succesfully retrieved schema
+          schema:
+            $ref: "#/definitions/sds_schema"
+        400:
+          description: Incorrect key
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                example: 400
+              message:
+                type: string
+                example: Invalid parameter provided
+            required:
+              - status
+              - message
+        404:
+          description: No schema found
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                example: 404
+              message:
+                type: string
+                example: No schema found
+            required:
+              - status
+              - message
+        500:
+          description: Internal error
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                example: 500
+              message:
+                type: string
+                example: Unable to process request
+            required:
+              - status
+              - message
+              
   /v1/schema_metadata:
     get:
       description: GET method that returns the schema metadata corresponding to the given survey_id.
@@ -236,7 +292,7 @@ paths:
                 example: 400
               message:
                 type: string
-                example: Validation has failed
+                example: Invalid search provided
             required:
               - status
               - message
@@ -296,7 +352,7 @@ paths:
                 example: 400
               message:
                 type: string
-                example: Validation has failed
+                example: Invalid search parameters provided
             required:
               - status
               - message

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -13,6 +13,10 @@ app.add_exception_handler(
     ExceptionInterceptor.throw_400_incorrect_schema_key_exception,
 )
 app.add_exception_handler(
+    exceptions.ExceptionIncorrectSchemaV2Key,
+    ExceptionInterceptor.throw_400_incorrect_schema_v2_key_exception,
+)
+app.add_exception_handler(
     exceptions.ExceptionNoSchemaMetadataCollection,
     ExceptionInterceptor.throw_404_no_schemas_metadata_exception,
 )

--- a/src/app/exception/exception_interceptor.py
+++ b/src/app/exception/exception_interceptor.py
@@ -28,10 +28,21 @@ class ExceptionInterceptor:
         request: Request, exc: Exception
     ) -> JSONResponse:
         """
-        When wrong search parameters are supplied for schema metadata query and a 400 HTTP response is returned.
+        When wrong search parameters are supplied for schema or schema metadata query and a 400 HTTP response is returned.
         """
         er = ExceptionResponder(
             status.HTTP_400_BAD_REQUEST, "error", "Invalid search provided"
+        )
+        return er.throw_er_with_json()
+
+    def throw_400_incorrect_schema_v2_key_exception(
+        request: Request, exc: Exception
+    ) -> JSONResponse:
+        """
+        When wrong search parameters are supplied for schema v2 query and a 400 HTTP response is returned.
+        """
+        er = ExceptionResponder(
+            status.HTTP_400_BAD_REQUEST, "error", "Invalid parameter provided"
         )
         return er.throw_er_with_json()
 

--- a/src/app/exception/exceptions.py
+++ b/src/app/exception/exceptions.py
@@ -9,6 +9,10 @@ class ExceptionIncorrectSchemaKey(Exception):
     pass
 
 
+class ExceptionIncorrectSchemaV2Key(Exception):
+    pass
+
+
 class ExceptionNoSchemaMetadataCollection(Exception):
     pass
 

--- a/src/app/repositories/firebase/schema_firebase_repository.py
+++ b/src/app/repositories/firebase/schema_firebase_repository.py
@@ -121,6 +121,19 @@ class SchemaFirebaseRepository:
         for schema in schemas_result:
             return schema.to_dict()["schema_location"]
 
+    def get_schema_bucket_filename_with_guid(self, guid: str) -> str:
+        """
+        Gets the filename of the schema of a specific guid. Should only ever return one entry.
+
+        Parameters:
+        guid (str): The guid of the survey being queried.
+        """
+
+        schemas_result = self.schemas_collection.where("guid", "==", guid).stream()
+
+        for schema in schemas_result:
+            return schema.to_dict()["schema_location"]
+
     def get_schema_metadata_collection(self, survey_id: str) -> list[SchemaMetadata]:
         """
         Gets the collection of schema metadata with a specific survey id.

--- a/src/app/routers/schema_router.py
+++ b/src/app/routers/schema_router.py
@@ -24,6 +24,7 @@ async def post_schema(
     Posts the schema metadata to be processed.
 
     Parameters:
+    survey_id (str): survey_id of the schema
     schema (dict): schema to be processed in JSON format.
     schema_processor_service (SchemaProcessorService): injected processor service for processing the schema.
     """
@@ -77,9 +78,8 @@ async def get_schema_from_bucket(
         logger.error("Schema metadata not found")
         raise exceptions.ExceptionNoSchemaFound
 
-    logger.info("Bucket schema location successfully retrieved.")
     logger.debug(f"Bucket schema location: {bucket_schema_filename}")
-    logger.info("Getting schema...")
+    logger.info("Bucket schema location successfully retrieved. Getting schema...")
 
     schema = schema_bucket_repository.get_schema_file_as_json(bucket_schema_filename)
 
@@ -119,9 +119,8 @@ async def get_schema_from_bucket_with_guid(
         logger.error("Schema metadata not found")
         raise exceptions.ExceptionNoSchemaFound
 
-    logger.info("Bucket schema location successfully retrieved.")
     logger.debug(f"Bucket schema location: {bucket_schema_filename}")
-    logger.info("Getting schema...")
+    logger.info("Bucket schema location successfully retrieved. Getting schema...")
 
     schema = schema_bucket_repository.get_schema_file_as_json(bucket_schema_filename)
 

--- a/src/app/routers/schema_router.py
+++ b/src/app/routers/schema_router.py
@@ -90,7 +90,7 @@ async def get_schema_from_bucket(
 
 
 @router.get("/v2/schema")
-async def get_schema_from_bucket(
+async def get_schema_from_bucket_with_guid(
     guid: str = None,
     schema_bucket_repository: SchemaBucketRepository = Depends(),
     schema_processor_service: SchemaProcessorService = Depends(),

--- a/src/app/services/dataset/dataset_writer_service.py
+++ b/src/app/services/dataset/dataset_writer_service.py
@@ -45,9 +45,10 @@ class DatasetWriterService:
                 unit_data_collection_with_metadata,
                 extracted_unit_data_identifiers,
             )
-            logger.info("Dataset transaction committed successfully.")
+            logger.info(
+                "Dataset transaction committed successfully. Publishing dataset metadata to topic..."
+            )
 
-            logger.info("Publishing dataset metadata to topic.")
             return {
                 **dataset_metadata_without_id,
                 "dataset_id": dataset_id,

--- a/src/app/services/schema/schema_processor_service.py
+++ b/src/app/services/schema/schema_processor_service.py
@@ -179,6 +179,17 @@ class SchemaProcessorService:
                 survey_id, version
             )
 
+    def get_schema_bucket_filename_from_guid(self, guid: str) -> str:
+        """
+        Gets the filename of the schema in bucket from guid
+
+        Parameters:
+        guid (str): the guid of the schema
+        """
+        return self.schema_firebase_repository.get_schema_bucket_filename_with_guid(
+            guid
+        )
+
     def try_publish_schema_metadata_to_topic(
         self, next_version_schema_metadata: SchemaMetadata
     ) -> None:

--- a/src/app/services/validators/query_parameter_validator_service.py
+++ b/src/app/services/validators/query_parameter_validator_service.py
@@ -19,9 +19,9 @@ class QueryParameterValidatorService:
             raise exceptions.ValidationException
 
     @staticmethod
-    def validate_schema_version_parses(version: str) -> None:
+    def validate_schema_version_from_get_schema(version: str) -> None:
         """
-        Validates the schema version parses to an integer
+        Validates the version from get schema v1 endpoint
 
         Parameters:
         version: version of the schema metadata
@@ -31,7 +31,31 @@ class QueryParameterValidatorService:
                 version = int(version)
             except ValueError:
                 logger.error("Invalid version")
-                raise RequestValidationError(errors=ValueError)
+                raise exceptions.ExceptionIncorrectSchemaKey
+
+    @staticmethod
+    def validate_survey_id_from_get_schema(survey_id: str) -> None:
+        """
+        Validates the survey id from get schema v1 endpoint
+
+        Parameters:
+        survey_id: survey id of the schema
+        """
+        if survey_id is None:
+            logger.error("Survey ID not set")
+            raise exceptions.ExceptionIncorrectSchemaKey
+
+    @staticmethod
+    def validate_guid_from_get_schema(guid: str) -> None:
+        """
+        Validates the guid from get schema v2 endpoint
+
+        Parameters:
+        guid: guid of the schema
+        """
+        if guid is None:
+            logger.error("GUID not set")
+            raise exceptions.ExceptionIncorrectSchemaV2Key
 
     @staticmethod
     def validate_survey_id_from_schema_metadata(survey_id: str) -> None:

--- a/src/app/services/validators/query_parameter_validator_service.py
+++ b/src/app/services/validators/query_parameter_validator_service.py
@@ -1,5 +1,4 @@
 import exception.exceptions as exceptions
-from fastapi.exceptions import RequestValidationError
 from logging_config import logging
 
 logger = logging.getLogger(__name__)

--- a/src/integration_tests/schemas/e2e_schema_integration_test.py
+++ b/src/integration_tests/schemas/e2e_schema_integration_test.py
@@ -87,7 +87,7 @@ class E2ESchemaIntegrationTest(TestCase):
             assert latest_version_schema_response.json() == test_schema
 
             set_guid_schema_response = session.get(
-                f"{config.API_URL}/v2/schema?" f"guid={schema['guid']}",
+                f"{config.API_URL}/v2/schema?guid={schema['guid']}",
                 headers=headers,
             )
 

--- a/src/integration_tests/schemas/e2e_schema_integration_test.py
+++ b/src/integration_tests/schemas/e2e_schema_integration_test.py
@@ -85,3 +85,11 @@ class E2ESchemaIntegrationTest(TestCase):
 
             assert latest_version_schema_response.status_code == 200
             assert latest_version_schema_response.json() == test_schema
+
+            set_guid_schema_response = session.get(
+                f"{config.API_URL}/v2/schema?" f"guid={schema['guid']}",
+                headers=headers,
+            )
+
+            assert set_guid_schema_response.status_code == 200
+            assert set_guid_schema_response.json() == test_schema

--- a/src/unit_tests/schema/get_schema_from_bucket_test.py
+++ b/src/unit_tests/schema/get_schema_from_bucket_test.py
@@ -193,7 +193,7 @@ def test_get_schema_with_missing_guid_error(test_client):
     response = test_client.get("/v2/schema")
 
     assert response.status_code == 400
-    assert response.json()["message"] == "Invalid search provided"
+    assert response.json()["message"] == "Invalid parameter provided"
 
 
 def test_get_schema_metadata_with_incorrect_key(test_client):

--- a/src/unit_tests/schema/post_schema_test.py
+++ b/src/unit_tests/schema/post_schema_test.py
@@ -105,6 +105,18 @@ class PostSchemaTest(TestCase):
             schema_test_data.test_filename,
         )
 
+    def test_post_schema_with_invalid_dict(self):
+        """
+        Checks that fastAPI returns a 400 error with appropriate
+        message if the schema is not a valid dictionary.
+        """
+        response = self.test_client.post(
+            "/v1/schema?survey_id=",
+            json="invalid_json",
+        )
+        assert response.status_code == 400
+        assert response.json()["message"] == "Validation has failed"
+
     def test_post_schema_with_missing_survey_id_400_response(self):
         """
         Checks that fastAPI returns a 400 error with appropriate


### PR DESCRIPTION
### Motivation and Context
A new schema endpoint to use GUID as the query parameter to retrieve schema

### What has changed
- A new endpoint v2/schema using GET method is added to schema_router
- A validation process and exception handling method are added
- Add related unit tests and add endpoint to integration test
- Change openapi and devtools accordingly
- Update readme and openapi to match previous changes

### How to test?
Pass unit test and integration test

### Links
https://jira.ons.gov.uk/browse/SDSS-186
