### PR TITLE
Sdss 197 use dockerhub to deploy images

### DIFF
--- a/cloudbuild-preprod.yaml
+++ b/cloudbuild-preprod.yaml
@@ -8,27 +8,25 @@ steps:
     - |
       gcloud auth configure-docker europe-west2-docker.pkg.dev
 
-  # Docker Build
+  # Docker Pull Image from dockerhub, tag, push and deploy to cloudrun
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['build', '-t', 'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-preprod:${SHORT_SHA}', '-t', 'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-preprod:latest', '-t', 'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-preprod:${TAG_NAME}',  '.' ]
-
-  # Docker push to Google Artifact Registry
+    id: 'Pull image from dockerhub'
+    args: [ 'pull', 'onsdigital/sds' ]
   - name: 'gcr.io/cloud-builders/docker'
-    args: [ 'push',  'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-preprod:${SHORT_SHA}' ]
-
-  # Docker push latest tag to Google Artifact Registry
+    id: 'Tag the image with SHA'
+    args: [ 'tag', 'onsdigital/sds:latest', 'gcr.io/${_PROJECT_ID}/sds/sds-preprod:$SHORT_SHA' ]
   - name: 'gcr.io/cloud-builders/docker'
-    args: [ 'push',  'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-preprod:latest' ]
-
-  # Docker push version tag to Google Artifact Registry
+    id: 'Push image to GCR'
+    args: [ 'push', 'gcr.io/${_PROJECT_ID}/sds/sds-preprod:$SHORT_SHA' ]
   - name: 'gcr.io/cloud-builders/docker'
-    args: [ 'push',  'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-preprod:${TAG_NAME}' ]
-
-  # Runs the Docker image pushed
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    id: "Run image"
-    entrypoint: gcloud
-    args: [ 'run', 'deploy', 'sds', '--image', 'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-preprod:$SHORT_SHA',
+    id: 'Tag the image with Version'
+    args: [ 'tag', 'onsdigital/sds:latest', 'gcr.io/${_PROJECT_ID}/sds/sds-preprod:${TAG_NAME}' ]
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'Push image to GCR'
+    args: [ 'push', 'gcr.io/${_PROJECT_ID}/sds/sds-preprod:${TAG_NAME}' ]
+  - name: 'gcr.io/cloud-builders/gcloud'
+    id: 'Deploy the image to cloudrun'
+    args: [ 'run', 'deploy', 'sds', '--image', 'gcr.io/${_PROJECT_ID}/sds/sds-preprod:$SHORT_SHA',
             '--region', 'europe-west2', '--allow-unauthenticated', '--ingress', 'internal-and-cloud-load-balancing' ]
 
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'

--- a/cloudbuild-preprod.yaml
+++ b/cloudbuild-preprod.yaml
@@ -16,13 +16,13 @@ steps:
     id: 'Tag the image with SHA'
     args: [ 'tag', 'onsdigital/sds:latest', 'gcr.io/${_PROJECT_ID}/sds/sds-preprod:$SHORT_SHA' ]
   - name: 'gcr.io/cloud-builders/docker'
-    id: 'Push image to GCR'
+    id: 'Push SHA Tagged Image to GCR'
     args: [ 'push', 'gcr.io/${_PROJECT_ID}/sds/sds-preprod:$SHORT_SHA' ]
   - name: 'gcr.io/cloud-builders/docker'
     id: 'Tag the image with Version'
     args: [ 'tag', 'onsdigital/sds:latest', 'gcr.io/${_PROJECT_ID}/sds/sds-preprod:${TAG_NAME}' ]
   - name: 'gcr.io/cloud-builders/docker'
-    id: 'Push image to GCR'
+    id: 'Push Version Tagged Image to GCR'
     args: [ 'push', 'gcr.io/${_PROJECT_ID}/sds/sds-preprod:${TAG_NAME}' ]
   - name: 'gcr.io/cloud-builders/gcloud'
     id: 'Deploy the image to cloudrun'

--- a/cloudbuild-preprod.yaml
+++ b/cloudbuild-preprod.yaml
@@ -18,12 +18,6 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     id: 'Push SHA Tagged Image to GCR'
     args: [ 'push', 'gcr.io/${_PROJECT_ID}/sds/sds-preprod:$SHORT_SHA' ]
-  - name: 'gcr.io/cloud-builders/docker'
-    id: 'Tag the image with Version'
-    args: [ 'tag', 'onsdigital/sds:latest', 'gcr.io/${_PROJECT_ID}/sds/sds-preprod:${TAG_NAME}' ]
-  - name: 'gcr.io/cloud-builders/docker'
-    id: 'Push Version Tagged Image to GCR'
-    args: [ 'push', 'gcr.io/${_PROJECT_ID}/sds/sds-preprod:${TAG_NAME}' ]
   - name: 'gcr.io/cloud-builders/gcloud'
     id: 'Deploy the image to cloudrun'
     args: [ 'run', 'deploy', 'sds', '--image', 'gcr.io/${_PROJECT_ID}/sds/sds-preprod:$SHORT_SHA',

--- a/cloudbuild-prod.yaml
+++ b/cloudbuild-prod.yaml
@@ -8,27 +8,25 @@ steps:
     - |
       gcloud auth configure-docker europe-west2-docker.pkg.dev
 
-  # Docker Build
+  # Docker Pull Image from dockerhub, tag, push and deploy to cloudrun
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['build', '-t', 'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-prod:${SHORT_SHA}', '-t', 'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-prod:latest', '-t', 'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-prod:${TAG_NAME}',  '.' ]
-
-  # Docker push to Google Artifact Registry
+    id: 'Pull image from dockerhub'
+    args: [ 'pull', 'onsdigital/sds' ]
   - name: 'gcr.io/cloud-builders/docker'
-    args: [ 'push',  'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-prod:${SHORT_SHA}' ]
-
-  # Docker push latest tag to Google Artifact Registry
+    id: 'Tag the image with SHA'
+    args: [ 'tag', 'onsdigital/sds:latest', 'gcr.io/${_PROJECT_ID}/sds/sds-prod:$SHORT_SHA' ]
   - name: 'gcr.io/cloud-builders/docker'
-    args: [ 'push',  'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-prod:latest' ]
-
-  # Docker push version tag to Google Artifact Registry
+    id: 'Push image to GCR'
+    args: [ 'push', 'gcr.io/${_PROJECT_ID}/sds/sds-prod:$SHORT_SHA' ]
   - name: 'gcr.io/cloud-builders/docker'
-    args: [ 'push',  'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-prod:${TAG_NAME}' ]
-
-  # Runs the Docker image pushed
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    id: "Run image"
-    entrypoint: gcloud
-    args: [ 'run', 'deploy', 'sds', '--image', 'europe-west2-docker.pkg.dev/${_PROJECT_ID}/sds/sds-prod:$SHORT_SHA',
+    id: 'Tag the image with Version'
+    args: [ 'tag', 'onsdigital/sds:latest', 'gcr.io/${_PROJECT_ID}/sds/sds-prod:${TAG_NAME}' ]
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'Push image to GCR'
+    args: [ 'push', 'gcr.io/${_PROJECT_ID}/sds/sds-prod:${TAG_NAME}' ]
+  - name: 'gcr.io/cloud-builders/gcloud'
+    id: 'Deploy the image to cloudrun'
+    args: [ 'run', 'deploy', 'sds', '--image', 'gcr.io/${_PROJECT_ID}/sds/sds-prod:$SHORT_SHA',
             '--region', 'europe-west2', '--allow-unauthenticated', '--ingress', 'internal-and-cloud-load-balancing' ]
 
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'

--- a/cloudbuild-prod.yaml
+++ b/cloudbuild-prod.yaml
@@ -18,12 +18,6 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     id: 'Push SHA Tagged Image to GCR'
     args: [ 'push', 'gcr.io/${_PROJECT_ID}/sds/sds-prod:$SHORT_SHA' ]
-  - name: 'gcr.io/cloud-builders/docker'
-    id: 'Tag the image with Version'
-    args: [ 'tag', 'onsdigital/sds:latest', 'gcr.io/${_PROJECT_ID}/sds/sds-prod:${TAG_NAME}' ]
-  - name: 'gcr.io/cloud-builders/docker'
-    id: 'Push Version Tagged Image to GCR'
-    args: [ 'push', 'gcr.io/${_PROJECT_ID}/sds/sds-prod:${TAG_NAME}' ]
   - name: 'gcr.io/cloud-builders/gcloud'
     id: 'Deploy the image to cloudrun'
     args: [ 'run', 'deploy', 'sds', '--image', 'gcr.io/${_PROJECT_ID}/sds/sds-prod:$SHORT_SHA',

--- a/cloudbuild-prod.yaml
+++ b/cloudbuild-prod.yaml
@@ -16,13 +16,13 @@ steps:
     id: 'Tag the image with SHA'
     args: [ 'tag', 'onsdigital/sds:latest', 'gcr.io/${_PROJECT_ID}/sds/sds-prod:$SHORT_SHA' ]
   - name: 'gcr.io/cloud-builders/docker'
-    id: 'Push image to GCR'
+    id: 'Push SHA Tagged Image to GCR'
     args: [ 'push', 'gcr.io/${_PROJECT_ID}/sds/sds-prod:$SHORT_SHA' ]
   - name: 'gcr.io/cloud-builders/docker'
     id: 'Tag the image with Version'
     args: [ 'tag', 'onsdigital/sds:latest', 'gcr.io/${_PROJECT_ID}/sds/sds-prod:${TAG_NAME}' ]
   - name: 'gcr.io/cloud-builders/docker'
-    id: 'Push image to GCR'
+    id: 'Push Version Tagged Image to GCR'
     args: [ 'push', 'gcr.io/${_PROJECT_ID}/sds/sds-prod:${TAG_NAME}' ]
   - name: 'gcr.io/cloud-builders/gcloud'
     id: 'Deploy the image to cloudrun'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -40,6 +40,12 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     id: 'Push image to GCR'
     args: ['push', 'gcr.io/${_PROJECT_ID}/sds/sds:$SHORT_SHA']
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'Tag the image with Version'
+    args: [ 'tag', 'onsdigital/sds:latest', 'gcr.io/${_PROJECT_ID}/sds/sds:${TAG_NAME}' ]
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'Push image to GCR'
+    args: [ 'push', 'gcr.io/${_PROJECT_ID}/sds/sds:${TAG_NAME}' ]
   - name: 'gcr.io/cloud-builders/gcloud'
     id: 'Deploy the image to cloudrun'
     args: [ 'run', 'deploy', 'sds', '--image', 'gcr.io/${_PROJECT_ID}/sds/sds:$SHORT_SHA',

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -38,14 +38,14 @@ steps:
     id: 'Tag the image with SHA'
     args: ['tag', 'onsdigital/sds:latest', 'gcr.io/${_PROJECT_ID}/sds/sds:$SHORT_SHA']
   - name: 'gcr.io/cloud-builders/docker'
+    id: 'Tag the image with Version'
+    args: [ 'tag', 'onsdigital/sds:latest', 'gcr.io/${_PROJECT_ID}/sds/sds:${TAG_NAME}']
+  - name: 'gcr.io/cloud-builders/docker'
     id: 'Push SHA Tagged Image to GCR'
     args: ['push', 'gcr.io/${_PROJECT_ID}/sds/sds:$SHORT_SHA']
   - name: 'gcr.io/cloud-builders/docker'
-    id: 'Tag the image with Version'
-    args: [ 'tag', 'onsdigital/sds:latest', 'gcr.io/${_PROJECT_ID}/sds/sds:${TAG_NAME}' ]
-  - name: 'gcr.io/cloud-builders/docker'
     id: 'Push Version Tagged Image to GCR'
-    args: [ 'push', 'gcr.io/${_PROJECT_ID}/sds/sds:${TAG_NAME}' ]
+    args: [ 'push', 'gcr.io/${_PROJECT_ID}/sds/sds:${TAG_NAME}']
   - name: 'gcr.io/cloud-builders/gcloud'
     id: 'Deploy the image to cloudrun'
     args: [ 'run', 'deploy', 'sds', '--image', 'gcr.io/${_PROJECT_ID}/sds/sds:$SHORT_SHA',

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -38,14 +38,8 @@ steps:
     id: 'Tag the image with SHA'
     args: ['tag', 'onsdigital/sds:latest', 'gcr.io/${_PROJECT_ID}/sds/sds:$SHORT_SHA']
   - name: 'gcr.io/cloud-builders/docker'
-    id: 'Tag the image with Version'
-    args: [ 'tag', 'onsdigital/sds:latest', 'gcr.io/${_PROJECT_ID}/sds/sds:${TAG_NAME}']
-  - name: 'gcr.io/cloud-builders/docker'
     id: 'Push SHA Tagged Image to GCR'
     args: ['push', 'gcr.io/${_PROJECT_ID}/sds/sds:$SHORT_SHA']
-  - name: 'gcr.io/cloud-builders/docker'
-    id: 'Push Version Tagged Image to GCR'
-    args: [ 'push', 'gcr.io/${_PROJECT_ID}/sds/sds:${TAG_NAME}']
   - name: 'gcr.io/cloud-builders/gcloud'
     id: 'Deploy the image to cloudrun'
     args: [ 'run', 'deploy', 'sds', '--image', 'gcr.io/${_PROJECT_ID}/sds/sds:$SHORT_SHA',

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -35,16 +35,16 @@ steps:
     id: 'Pull image from dockerhub'
     args: ['pull', 'onsdigital/sds']
   - name: 'gcr.io/cloud-builders/docker'
-    id: 'Tag the image'
+    id: 'Tag the image with SHA'
     args: ['tag', 'onsdigital/sds:latest', 'gcr.io/${_PROJECT_ID}/sds/sds:$SHORT_SHA']
   - name: 'gcr.io/cloud-builders/docker'
-    id: 'Push image to GCR'
+    id: 'Push SHA Tagged Image to GCR'
     args: ['push', 'gcr.io/${_PROJECT_ID}/sds/sds:$SHORT_SHA']
   - name: 'gcr.io/cloud-builders/docker'
     id: 'Tag the image with Version'
     args: [ 'tag', 'onsdigital/sds:latest', 'gcr.io/${_PROJECT_ID}/sds/sds:${TAG_NAME}' ]
   - name: 'gcr.io/cloud-builders/docker'
-    id: 'Push image to GCR'
+    id: 'Push Version Tagged Image to GCR'
     args: [ 'push', 'gcr.io/${_PROJECT_ID}/sds/sds:${TAG_NAME}' ]
   - name: 'gcr.io/cloud-builders/gcloud'
     id: 'Deploy the image to cloudrun'


### PR DESCRIPTION
### Motivation and Context
Moving from GAR to dockerhub for deploying images to cloudrun, so if images within an artifact registry within the project were destroyed with Terraform , we can build using latest image from dockerhub.

### What has changed
Changes made to cloudbuild.yaml, cloudbuild-preprod.yaml & cloudbuild-prod.yaml to pull image from dockerhub, tag & push to google cloud repo and then deploy to cloudrun.

### How to test?
All checks passed in PR.

### Links
[SDSS-197](https://jira.ons.gov.uk/browse/SDSS-197)