### PR TITLE
using python:3.11-alpine base image for all cloudbuild steps

### DIFF
--- a/cloudbuild-dev.yaml
+++ b/cloudbuild-dev.yaml
@@ -32,7 +32,7 @@ steps:
     entrypoint: python
     args: ["-m", "flake8", "src", "devtools", "--max-line-length=127"]
 
-  - name: python:3.11-alpine
+  - name: python:3.11
     id: "unit tests"
     entrypoint: sh
     args:

--- a/cloudbuild-dev.yaml
+++ b/cloudbuild-dev.yaml
@@ -1,33 +1,37 @@
 steps:
-  - name: python:3.11-alpine
+  - name: python:3.11
     entrypoint: "python"
     args: ["-m", "pip", "install", "--upgrade", "pip", "--user"]
-  - name: python:3.11-alpine
+
+  - name: python:3.11
     id: "Setup Python"
     entrypoint: python
     args: ["-m", "pip", "install", "-r", "requirements.txt", "--user"]
 
-  - name: python:3.11-alpine
+  - name: python:3.11
     id: "Audit packages"
     entrypoint: sh
     args:
       - "-c"
       - |
         make audit
-  - name: python:3.11-alpine
+
+  - name: python:3.11
     id: "black"
     entrypoint: python
     args: ["-m", "black", "src", "devtools", "--check"]
-  - name: python:3.11-alpine
+
+  - name: python:3.11
     id: "isort"
     entrypoint: python
     args:
       ["-m", "isort", "src", "devtools", "--check-only", "--profile", "black"]
 
-  - name: python:3.11-alpine
+  - name: python:3.11
     id: "flake8"
     entrypoint: python
     args: ["-m", "flake8", "src", "devtools", "--max-line-length=127"]
+
   - name: python:3.11-alpine
     id: "unit tests"
     entrypoint: sh
@@ -73,7 +77,7 @@ steps:
         gcloud alpha artifacts docker images describe europe-west2-docker.pkg.dev/${PROJECT_ID}/sds/sds:latest \
         --show-package-vulnerability --format=json | tee /dev/fd/2 > vulnerability_report.txt
 
-  - name: "python:3.11-alpine"
+  - name: "python:3.11"
     id: "Check for critical vulnerabilities"
     entrypoint: sh
     args:
@@ -103,6 +107,7 @@ steps:
         --trigger-event-filters="type=google.cloud.storage.object.v1.finalized" \
         --trigger-event-filters="bucket=${_DATASET_BUCKET_NAME}" \
         --set-env-vars="DATASET_BUCKET_NAME=${_DATASET_BUCKET_NAME},SCHEMA_BUCKET_NAME=${_SCHEMA_BUCKET_NAME},CONF=cloud-build,AUTODELETE_DATASET_BUCKET_FILE=${_AUTODELETE_DATASET_BUCKET_FILE},RETAIN_DATASET_FIRESTORE=${_RETAIN_DATASET_FIRESTORE},LOG_LEVEL=${_LOG_LEVEL},PROJECT_ID=${PROJECT_ID},PUBLISH_SCHEMA_TOPIC_ID=${_PUBLISH_SCHEMA_TOPIC_ID},PUBLISH_DATASET_TOPIC_ID=${_PUBLISH_DATASET_TOPIC_ID},FIRESTORE_DB_NAME=${_FIRESTORE_DB_NAME},SURVEY_MAP_URL=${_SURVEY_MAP_URL}"
+
   - name: "gcr.io/cloud-builders/gcloud"
     id: "Retrieve `OAUTH_BRAND_NAME` and save it to workspace"
     entrypoint: sh
@@ -111,6 +116,7 @@ steps:
       - |
         gcloud iap oauth-brands list --format='value(name)' --limit=1 --project=${PROJECT_ID} \
         > /workspace/oauth_brand_name
+
   - name: "gcr.io/cloud-builders/gcloud"
     id: "Retrieve `OAUTH_CLIENT_NAME` and save it to workspace"
     entrypoint: sh
@@ -120,7 +126,8 @@ steps:
         gcloud iap oauth-clients list $(cat /workspace/oauth_brand_name) --format='value(name)' \
         --limit=1 \
         > /workspace/oauth_client_name
-  - name: python:3.11-alpine
+
+  - name: python:3.11
     id: "Run integration test"
     entrypoint: sh
     args:

--- a/cloudbuild-dev.yaml
+++ b/cloudbuild-dev.yaml
@@ -1,34 +1,34 @@
 steps:
-  - name: python:3.11
+  - name: python:3.11-alpine
     entrypoint: "python"
     args: ["-m", "pip", "install", "--upgrade", "pip", "--user"]
-  - name: python:3.11
+  - name: python:3.11-alpine
     id: "Setup Python"
     entrypoint: python
     args: ["-m", "pip", "install", "-r", "requirements.txt", "--user"]
 
-  - name: python:3.11
+  - name: python:3.11-alpine
     id: "Audit packages"
     entrypoint: sh
     args:
       - "-c"
       - |
         make audit
-  - name: python:3.11
+  - name: python:3.11-alpine
     id: "black"
     entrypoint: python
     args: ["-m", "black", "src", "devtools", "--check"]
-  - name: python:3.11
+  - name: python:3.11-alpine
     id: "isort"
     entrypoint: python
     args:
       ["-m", "isort", "src", "devtools", "--check-only", "--profile", "black"]
 
-  - name: python:3.11
+  - name: python:3.11-alpine
     id: "flake8"
     entrypoint: python
     args: ["-m", "flake8", "src", "devtools", "--max-line-length=127"]
-  - name: python:3.11
+  - name: python:3.11-alpine
     id: "unit tests"
     entrypoint: sh
     args:
@@ -73,7 +73,7 @@ steps:
         gcloud alpha artifacts docker images describe europe-west2-docker.pkg.dev/${PROJECT_ID}/sds/sds:latest \
         --show-package-vulnerability --format=json | tee /dev/fd/2 > vulnerability_report.txt
 
-  - name: "alpine"
+  - name: "python:3.11-alpine"
     id: "Check for critical vulnerabilities"
     entrypoint: sh
     args:
@@ -120,7 +120,7 @@ steps:
         gcloud iap oauth-clients list $(cat /workspace/oauth_brand_name) --format='value(name)' \
         --limit=1 \
         > /workspace/oauth_client_name
-  - name: python:3.11
+  - name: python:3.11-alpine
     id: "Run integration test"
     entrypoint: sh
     args:


### PR DESCRIPTION
### Motivation and Context
We should make sure we use the same base image across the `Dockerfile` and `cloudbuild-dev.yaml` steps to make sure any vulnerabilities found are consistent across the containers we build.

### What has changed
* `cloudbuild-dev.yaml` updated to use `python:3.11-alpine` base image for each step