### PR TITLE
CIR-177 Fixing FIRESTORE_DB_NAME

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - PUBLISH_SCHEMA_TOPIC_ID=ons-sds-publish-schema
       - PUBLISH_DATASET_TOPIC_ID=ons-sds-publish-dataset
       - SURVEY_MAP_URL=https://raw.githubusercontent.com/ONSdigital/sds-schema-definitions/main/mapping/survey_map.json
-      - FIRESTORE_DB_NAME=firestore_db
+      - FIRESTORE_DB_NAME=(default)
     volumes:
       - ./src/app:/src
       - ./devtools:/devtools
@@ -78,7 +78,7 @@ services:
       - PUBLISH_SCHEMA_TOPIC_ID=ons-sds-publish-schema
       - PUBLISH_DATASET_TOPIC_ID=ons-sds-publish-dataset
       - SURVEY_MAP_URL=https://raw.githubusercontent.com/ONSdigital/sds-schema-definitions/main/mapping/survey_map.json
-      - FIRESTORE_DB_NAME=firestore_db
+      - FIRESTORE_DB_NAME=(default)
     volumes:
       - ./devtools:/devtools
     container_name: cloudfunction-new_dataset-sds

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - PUBLISH_SCHEMA_TOPIC_ID=ons-sds-publish-schema
       - PUBLISH_DATASET_TOPIC_ID=ons-sds-publish-dataset
       - SURVEY_MAP_URL=https://raw.githubusercontent.com/ONSdigital/sds-schema-definitions/main/mapping/survey_map.json
+      - FIRESTORE_DB_NAME=firestore_db
     volumes:
       - ./src/app:/src
       - ./devtools:/devtools
@@ -77,6 +78,7 @@ services:
       - PUBLISH_SCHEMA_TOPIC_ID=ons-sds-publish-schema
       - PUBLISH_DATASET_TOPIC_ID=ons-sds-publish-dataset
       - SURVEY_MAP_URL=https://raw.githubusercontent.com/ONSdigital/sds-schema-definitions/main/mapping/survey_map.json
+      - FIRESTORE_DB_NAME=firestore_db
     volumes:
       - ./devtools:/devtools
     container_name: cloudfunction-new_dataset-sds

--- a/src/app/config/config.py
+++ b/src/app/config/config.py
@@ -176,10 +176,12 @@ class ServiceEmulatorDevelopmentConfig(Config):
         self.FIRESTORE_EMULATOR_HOST = get_value_from_env("FIRESTORE_EMULATOR_HOST")
         self.STORAGE_EMULATOR_HOST = get_value_from_env("STORAGE_EMULATOR_HOST")
         self.PUBSUB_EMULATOR_HOST = get_value_from_env("PUBSUB_EMULATOR_HOST")
+        self.FIRESTORE_DB_NAME = "(default)"
 
     FIRESTORE_EMULATOR_HOST: str
     STORAGE_EMULATOR_HOST: str
     PUBSUB_EMULATOR_HOST: str
+    FIRESTORE_DB_NAME: str
 
 
 class CloudDevelopmentConfig(Config):


### PR DESCRIPTION
### Motivation and Context
This PR fixes the issue with the docker container which Mike found while reviewing [CIR-177](https://jira.ons.gov.uk/browse/CIR-177)

### What has changed
FIRESTORE_DB_NAME is set to `(default)`

### How to test?
Run `docker-compose up` 