### PR TITLE
Sdss 287 reduce vulnerability scanning

### DIFF
--- a/cloudbuild-dev.yaml
+++ b/cloudbuild-dev.yaml
@@ -54,6 +54,8 @@ steps:
         then
           gcloud alpha artifacts docker images describe europe-west2-docker.pkg.dev/${PROJECT_ID}/sds/sds:latest \
           --show-package-vulnerability --format=json | tee /dev/fd/2 > vulnerability_report.txt
+        else
+          echo "Step not run for ${PROJECT_ID}"
         fi
 
   - name: "gcr.io/cloud-builders/gcloud"
@@ -69,6 +71,8 @@ steps:
             echo "Error: Critical vulnerability found with image" >&2
             exit 1
           fi
+        else
+          echo "Step not run for ${PROJECT_ID}"
         fi
 
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"

--- a/cloudbuild-dev.yaml
+++ b/cloudbuild-dev.yaml
@@ -44,23 +44,6 @@ steps:
         docker push "europe-west2-docker.pkg.dev/${PROJECT_ID}/sds/sds:${SHORT_SHA}"
         docker push "europe-west2-docker.pkg.dev/${PROJECT_ID}/sds/sds:latest"
 
-  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
-    id: "Run container"
-    entrypoint: gcloud
-    args:
-      [
-        "run",
-        "deploy",
-        "sds",
-        "--image",
-        "europe-west2-docker.pkg.dev/${PROJECT_ID}/sds/sds:${SHORT_SHA}",
-        "--region",
-        "europe-west2",
-        "--allow-unauthenticated",
-        "--ingress",
-        "internal-and-cloud-load-balancing",
-      ]
-
   - name: "gcr.io/cloud-builders/gcloud"
     id: "Show image vulnerabilities (ons-sds-dev only)"
     entrypoint: bash
@@ -87,6 +70,23 @@ steps:
             exit 1
           fi
         fi
+
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    id: "Run container"
+    entrypoint: gcloud
+    args:
+      [
+        "run",
+        "deploy",
+        "sds",
+        "--image",
+        "europe-west2-docker.pkg.dev/${PROJECT_ID}/sds/sds:${SHORT_SHA}",
+        "--region",
+        "europe-west2",
+        "--allow-unauthenticated",
+        "--ingress",
+        "internal-and-cloud-load-balancing",
+      ]
 
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     id: "Deploy cloud function"

--- a/cloudbuild-dev.yaml
+++ b/cloudbuild-dev.yaml
@@ -62,24 +62,30 @@ steps:
       ]
 
   - name: "gcr.io/cloud-builders/gcloud"
-    id: "Show image vulnerabilities"
-    entrypoint: sh
+    id: "Show image vulnerabilities (ons-sds-dev only)"
+    entrypoint: bash
     args:
       - "-c"
       - |
-        gcloud alpha artifacts docker images describe europe-west2-docker.pkg.dev/${PROJECT_ID}/sds/sds:latest \
-        --show-package-vulnerability --format=json | tee /dev/fd/2 > vulnerability_report.txt
+        if [ ${PROJECT_ID} == "ons-sds-dev" ]
+        then
+          gcloud alpha artifacts docker images describe europe-west2-docker.pkg.dev/${PROJECT_ID}/sds/sds:latest \
+          --show-package-vulnerability --format=json | tee /dev/fd/2 > vulnerability_report.txt
+        fi
 
-  - name: "alpine"
-    id: "Check for critical vulnerabilities"
-    entrypoint: sh
+  - name: "gcr.io/cloud-builders/gcloud"
+    id: "Check for critical vulnerabilities (ons-sds-dev only)"
+    entrypoint: bash
     args:
       - "-c"
       - |
-        apk add jq
-        if jq -e '.package_vulnerability_summary.vulnerabilities.CRITICAL[] | select(.kind == "VULNERABILITY" and .vulnerability.severity == "CRITICAL")' vulnerability_report.txt > /dev/null; then
-          echo "Error: Critical vulnerability found with image" >&2
-          exit 1
+        if [ ${PROJECT_ID} == "ons-sds-dev" ]
+        then
+          apk add jq
+          if jq -e '.package_vulnerability_summary.vulnerabilities.CRITICAL[] | select(.kind == "VULNERABILITY" and .vulnerability.severity == "CRITICAL")' vulnerability_report.txt > /dev/null; then
+            echo "Error: Critical vulnerability found with image" >&2
+            exit 1
+          fi
         fi
 
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"


### PR DESCRIPTION
### Motivation and Context
https://jira.ons.gov.uk/browse/SDSS-287

### What has changed
* `cloudbuild-dev.yaml` updated to only run vulnerability scanning steps when on `ons-sds-dev` project. This will ensure the scanning is only run on merge to main triggers

### How to test?
* Check that the vulnerability checking steps do not do anything when run against `ons-sds-sandbox-01` (PR trigger)
* Check that the vulnerability checking steps do check the container when run against `ons-sds-dev` (merge to main trigger)