### PR TITLE
added different way of getting jq when using gcloud image

### DIFF
--- a/cloudbuild-dev.yaml
+++ b/cloudbuild-dev.yaml
@@ -53,7 +53,7 @@ steps:
         if [ ${PROJECT_ID} == "ons-sds-dev" ]
         then
           gcloud alpha artifacts docker images describe europe-west2-docker.pkg.dev/${PROJECT_ID}/sds/sds:latest \
-          --show-package-vulnerability --format=json | tee /dev/fd/2 > vulnerability_report.txt
+            --show-package-vulnerability --format=json | tee /dev/fd/2 > vulnerability_report.txt
         else
           echo "Step not run for ${PROJECT_ID}"
         fi
@@ -66,7 +66,7 @@ steps:
       - |
         if [ ${PROJECT_ID} == "ons-sds-dev" ]
         then
-          apk add jq
+          apt-get -y update && apt-get install -y jq
           if jq -e '.package_vulnerability_summary.vulnerabilities.CRITICAL[] | select(.kind == "VULNERABILITY" and .vulnerability.severity == "CRITICAL")' vulnerability_report.txt > /dev/null; then
             echo "Error: Critical vulnerability found with image" >&2
             exit 1


### PR DESCRIPTION
### Motivation and Context
https://jira.ons.gov.uk/browse/SDSS-287

### What has changed
* `cloudbuild-dev.yaml` updated to change the way we get the jq dependency in the vulnerability checking step. The existing `apk add jq` command didn't work with the `gcr.io/cloud-builders/gcloud` base image we're using, so changed this to use `apt-get`

### How to test?
* Check that the vulnerability checking steps do not do anything when run against `ons-sds-sandbox-01` (PR trigger)
* Check that the vulnerability checking steps do check the container when run against `ons-sds-dev` (merge to main trigger)