### PR TITLE
Sdss 287 reduce vulnerability scanning

### DIFF
--- a/cloudbuild-dev.yaml
+++ b/cloudbuild-dev.yaml
@@ -52,8 +52,8 @@ steps:
       - |
         if [ ${PROJECT_ID} == "ons-sds-dev" ]
         then
-          gcloud alpha artifacts docker images describe europe-west2-docker.pkg.dev/${PROJECT_ID}/sds/sds:latest \
-            --show-package-vulnerability --format=json | tee /dev/fd/2 > vulnerability_report.txt
+          gcloud artifacts vulnerabilities list europe-west2-docker.pkg.dev/${PROJECT_ID}/sds/sds:latest \
+            --format=json > /workspace/vulnerability_report
         else
           echo "Step not run for ${PROJECT_ID}"
         fi
@@ -67,8 +67,8 @@ steps:
         if [ ${PROJECT_ID} == "ons-sds-dev" ]
         then
           apt-get -y update && apt-get install -y jq
-          if jq -e '.package_vulnerability_summary.vulnerabilities.CRITICAL[] | select(.kind == "VULNERABILITY" and .vulnerability.severity == "CRITICAL")' vulnerability_report.txt > /dev/null; then
-            echo "Error: Critical vulnerability found with image" >&2
+          if jq -e '.[] | select( .vulnerability.effectiveSeverity == "CRITICAL")' /workspace/vulnerability_report > /dev/null; then
+            echo "Error: Critical vulnerability found with image"
             exit 1
           fi
         else


### PR DESCRIPTION
### Motivation and Context
https://jira.ons.gov.uk/browse/SDSS-287 third time lucky!

### What has changed
* `cloudbuild-dev.yaml` updated to change the way we check for container vulnerabilities. These steps are only run when on `ons-sds-dev` project. Previous version wasn't working.

### How to test?
* Check that the vulnerability checking steps do not do anything when run against `ons-sds-sandbox-01` (PR trigger)
* Check that the vulnerability checking steps do check the container when run against `ons-sds-dev` (merge to main trigger)