### PR TITLE
Tweak IaC to improve performance

### DIFF
--- a/cloudbuild-dev.yaml
+++ b/cloudbuild-dev.yaml
@@ -94,6 +94,10 @@ steps:
         "SDS_APPLICATION_VERSION=development",
         "--cpu-boost",
         "--session-affinity",
+        "--min-instances",
+        "1",
+        "--max-instances",
+        "2",
       ]
 
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"

--- a/cloudbuild-dev.yaml
+++ b/cloudbuild-dev.yaml
@@ -94,10 +94,6 @@ steps:
         "SDS_APPLICATION_VERSION=development",
         "--cpu-boost",
         "--session-affinity",
-        "--min-instances",
-        "2",
-        "--max-instances",
-        "8",
       ]
 
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"

--- a/cloudbuild-dev.yaml
+++ b/cloudbuild-dev.yaml
@@ -92,6 +92,12 @@ steps:
         "internal-and-cloud-load-balancing",
         "--update-env-vars",
         "SDS_APPLICATION_VERSION=development",
+        "--cpu-boost",
+        "--session-affinity",
+        "--min-instances",
+        "2",
+        "--max-instances",
+        "8",
       ]
 
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"

--- a/cloudbuild-prod.yaml
+++ b/cloudbuild-prod.yaml
@@ -34,6 +34,12 @@ steps:
         "internal-and-cloud-load-balancing",
         "--update-env-vars",
         "SDS_APPLICATION_VERSION=${TAG_NAME}",
+        "--cpu-boost",
+        "--session-affinity",
+        "--min-instances",
+        "2",
+        "--max-instances",
+        "8",
       ]
 
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"


### PR DESCRIPTION
### Motivation and Context
To tweak the IaC configuration to improve SDS performance. Respective justification of the IaC change can be found here: https://confluence.ons.gov.uk/display/SDC/Performance+Testing+-+Tweaking+IAC+configuration

### What has changed
When deploying SDS,
- Min instance is set to 2 (for PreProd and Prod)
- Max instance is set to 8 (for PreProd and Prod)
- Session Affinity is enabled
- Startup CPU boost is enabled 

### How to test?
Run PR / merge / release pipeline and check the configuration of SDS app on cloud run

### Links
https://jira.ons.gov.uk/browse/SDSS-272
https://confluence.ons.gov.uk/display/SDC/Performance+Testing+-+Tweaking+IAC+configuration

### Screenshots (if appropriate):