### PR TITLE
Sdss 806 auto create bucket/pubsub topic removal

### DIFF
--- a/src/app/app.py
+++ b/src/app/app.py
@@ -77,6 +77,14 @@ app.add_exception_handler(
     exceptions.ExceptionNoSurveyIDs,
     ExceptionInterceptor.throw_404_no_survey_id_exception,
 )
+app.add_exception_handler(
+    exceptions.ExceptionBucketNotFound,
+    ExceptionInterceptor.throw_500_global_exception,
+)
+app.add_exception_handler(
+    exceptions.ExceptionTopicNotFound,
+    ExceptionInterceptor.throw_500_global_exception,
+)
 
 
 @app.exception_handler(500)

--- a/src/app/exception/exceptions.py
+++ b/src/app/exception/exceptions.py
@@ -43,3 +43,11 @@ class ValidationException(Exception):
 
 class ExceptionNoSurveyIDs(Exception):
     pass
+
+
+class ExceptionBucketNotFound(Exception):
+    pass
+
+
+class ExceptionTopicNotFound(Exception):
+    pass

--- a/src/app/repositories/buckets/bucket_loader.py
+++ b/src/app/repositories/buckets/bucket_loader.py
@@ -1,3 +1,4 @@
+import exception.exceptions as exceptions
 from config.config_factory import config
 from google.cloud import exceptions, storage
 
@@ -37,9 +38,7 @@ class BucketLoader:
                 bucket_name,
             )
         except exceptions.NotFound:
-            bucket = __storage_client.create_bucket(
-                bucket_name,
-            )
+            raise exceptions.ExceptionBucketNotFound
 
         return bucket
 

--- a/src/app/repositories/buckets/bucket_loader.py
+++ b/src/app/repositories/buckets/bucket_loader.py
@@ -1,4 +1,4 @@
-import exception.exceptions as exceptions
+import exception.exceptions as exception
 from config.config_factory import config
 from google.cloud import exceptions, storage
 
@@ -38,7 +38,7 @@ class BucketLoader:
                 bucket_name,
             )
         except exceptions.NotFound:
-            raise exceptions.ExceptionBucketNotFound
+            raise exception.ExceptionBucketNotFound
 
         return bucket
 

--- a/src/app/services/shared/publisher_service.py
+++ b/src/app/services/shared/publisher_service.py
@@ -33,13 +33,12 @@ class PublisherService:
             topic_path, data=json.dumps(publish_data).encode("utf-8")
         )
 
-    def _verify_topic_exists(self, topic_path: str) -> bool:
+    def _verify_topic_exists(self, topic_path: str) -> None:
         """
-        Returns True if the topic exists otherwise raises 500 global error.
+        If the topic does not exist raises 500 global error.
         """
         try:
             self.publisher.get_topic(request={"topic": topic_path})
-            return True
         except Exception:
             raise exceptions.ExceptionTopicNotFound
 

--- a/src/app/services/shared/publisher_service.py
+++ b/src/app/services/shared/publisher_service.py
@@ -27,7 +27,7 @@ class PublisherService:
         topic_id: unique identifier of the topic the data is published to
         """
         topic_path = self.publisher.topic_path(config.PROJECT_ID, topic_id)
-        self._get_topic(topic_path)
+        self._verify_topic_exists(topic_path)
 
         self.publisher.publish(
             topic_path, data=json.dumps(publish_data).encode("utf-8")

--- a/src/app/services/shared/publisher_service.py
+++ b/src/app/services/shared/publisher_service.py
@@ -1,5 +1,6 @@
 import json
 
+import exception.exceptions as exceptions
 from config.config_factory import config
 from google.cloud.pubsub_v1 import PublisherClient
 from logging_config import logging
@@ -26,37 +27,21 @@ class PublisherService:
         topic_id: unique identifier of the topic the data is published to
         """
         topic_path = self.publisher.topic_path(config.PROJECT_ID, topic_id)
-        self._try_create_topic(topic_path)
+        self._get_topic(topic_path)
 
         self.publisher.publish(
             topic_path, data=json.dumps(publish_data).encode("utf-8")
         )
 
-    def _try_create_topic(self, topic_path: str) -> None:
+    def _verify_topic_exists(self, topic_path: str) -> bool:
         """
-        Try to creates a topic with a specified topic id if none exists.
-
-        Parameters:
-        topic_id: The unique id of the topic being created.
-        """
-        try:
-            if not self._topic_exists(topic_path):
-                logger.debug("Topic does not exists. Creating topic...")
-                self.publisher.create_topic(request={"name": topic_path})
-
-                logger.debug(f"Topic with path {topic_path} created successfully")
-        except Exception as e:
-            print(f"Fail to create topic. Topic path: {topic_path} Error: {e}")
-
-    def _topic_exists(self, topic_path: str) -> bool:
-        """
-        Returns True if the topic exists otherwise returns False.
+        Returns True if the topic exists otherwise raises 500 global error.
         """
         try:
             self.publisher.get_topic(request={"topic": topic_path})
             return True
         except Exception:
-            return False
+            raise exceptions.ExceptionTopicNotFound
 
 
 publisher_service = PublisherService()


### PR DESCRIPTION
### Motivation and Context
SDS will now return 500 global exception if bucket / pubsub topic cannot be found. This removes the logic that will create these resources within SDS if they don't exist. This should prevent the creation of 'self-titled' buckets and removes resource creation from SDS as this is handled by Terraform. 

### What has changed
- Removed logic to autocreate buckets and pubsub topics if they don't exist
- Added exception handlers for these cases to raise 500 global exception if these resources cannot be found. 

### How to test?
- Tested using local and sandbox integration/unit tests as well as manual testing in Dockerised env to ensure endpoints return 500 error when buckets cannot be found.

### Links
[Jira ticket](https://jira.ons.gov.uk/browse/SDSS-806)
