### PR TITLE
corrected dataset function name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ gcloud auth login
 gcloud config set project $PROJECT_NAME
 
 cd src/app/
-gcloud functions deploy http-new-dataset-function \
+gcloud functions deploy new-dataset-function \
 --no-allow-unauthenticated \
 --gen2 \
 --ingress-settings=all \


### PR DESCRIPTION
### Motivation and Context
Cloud scheduler job failed because it couldn't find the dataset function. Due to an incorrect name, http-new-dataset-function from the README is incorrect

### What has changed
The name of the dataset function changed from http-new-dataset-function to new-dataset-function 


### How to test?
 deploy cloud function from the README file in sds and check if the name is new-dataset-function instead of http-new-dataset-function 


### Links
https://jira.ons.gov.uk/browse/SDSS-835 