### PR TITLE
Tune config for SDS application on cloudbuild-dev and cloudbuild-prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ More information on this service can be found on Confluence:
 
 - https://confluence.ons.gov.uk/display/SDC/SDS
 
----
-
 ## Dockerized
 
 The docker-compose will launch the SDS application, two storage emulators(firebase and bucket), the new_dataset cloud function and a supporting publish dataset endpoint. The SDS application will also support hot reloading within the `/src/app` directory.
@@ -203,4 +201,4 @@ make integration-test-local
 
 # Contact
 
-- <sds.cir.team@ons.gov.uk>
+- [sds.cir.team@ons.gov.uk](mailto:sds.cir.team@ons.gov.uk)

--- a/cloudbuild-dev.yaml
+++ b/cloudbuild-dev.yaml
@@ -97,7 +97,9 @@ steps:
         "--min-instances",
         "1",
         "--max-instances",
-        "2",
+        "100",
+        "--concurrency",
+        "1",
       ]
 
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"

--- a/cloudbuild-prod.yaml
+++ b/cloudbuild-prod.yaml
@@ -39,7 +39,9 @@ steps:
         "--min-instances",
         "2",
         "--max-instances",
-        "8",
+        "500",
+        "--concurrency",
+        "1",
       ]
 
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"


### PR DESCRIPTION
### Motivation and Context
A follow up tuning of the SDS configuration after the scale test so that SDS can achieve best performance

### What has changed
Max concurrency per SDS container is set to 1 while increasing the max-instance to 100 and 500 respectively for sandboxes and prod/preprod/integration/performance environments.
Configurations across projects are referenced here:
https://confluence.ons.gov.uk/display/SDC/SDS+-+Configurations

### How to test?
All pipelines are passed.

### Links
https://jira.ons.gov.uk/browse/SDSS-680

### Screenshots (if appropriate):