### PR TITLE
Fix bugs in integration test

### DIFF
--- a/src/integration_tests/datasets/e2e_dataset_integration_test.py
+++ b/src/integration_tests/datasets/e2e_dataset_integration_test.py
@@ -7,7 +7,6 @@ from src.integration_tests.helpers.integration_helpers import (
     cleanup,
     create_dataset,
     create_filepath,
-    empty_dataset_bucket,
     generate_headers,
     load_json,
     pubsub_setup,
@@ -31,12 +30,12 @@ class E2EDatasetIntegrationTest(TestCase):
         cleanup()
         pubsub_setup(dataset_pubsub_helper, test_dataset_subscriber_id)
         pubsub_setup(dataset_error_pubsub_helper, test_dataset_error_subscriber_id)
-        empty_dataset_bucket()
 
     def tearDown(self) -> None:
         cleanup()
         pubsub_teardown(dataset_pubsub_helper, test_dataset_subscriber_id)
         pubsub_teardown(dataset_error_pubsub_helper, test_dataset_error_subscriber_id)
+
 
     def test_dataset_e2e(self):
         """
@@ -397,6 +396,7 @@ class E2EDatasetIntegrationTest(TestCase):
         with open(f"{config.TEST_DATASET_PATH}dataset_invalid_json.json", "r") as file:
             dataset_invalid_json = file.read()
             file.close()
+
         dataset_invalid_json_filename = create_filepath("integration-test-invalid-json")
         create_dataset_response = create_dataset_as_string(
             dataset_invalid_json_filename, dataset_invalid_json, session, headers

--- a/src/integration_tests/datasets/e2e_dataset_integration_test.py
+++ b/src/integration_tests/datasets/e2e_dataset_integration_test.py
@@ -13,7 +13,7 @@ from src.integration_tests.helpers.integration_helpers import (
     pubsub_setup,
     pubsub_teardown,
     setup_session,
-    create_filename_error_filepath,
+    create_dataset_as_string,
 )
 from src.integration_tests.helpers.pubsub_helper import (
     dataset_error_pubsub_helper,
@@ -370,9 +370,10 @@ class E2EDatasetIntegrationTest(TestCase):
         dataset_incorrect_extension = load_json(
             f"{config.TEST_DATASET_PATH}dataset.json"
         )
-        dataset_incorrect_extension_filename = create_filename_error_filepath(
+        dataset_incorrect_extension_filename = create_filepath(
             "integration-test-incorrect-extension"
-        )
+        ).replace(".json", ".txt")
+
         create_dataset_response = create_dataset(
             dataset_incorrect_extension_filename,
             dataset_incorrect_extension,
@@ -393,7 +394,7 @@ class E2EDatasetIntegrationTest(TestCase):
             assert received_messages[0][key] == value
 
         # Upload dataset with invalid json
-        """with open(f"{config.TEST_DATASET_PATH}dataset_invalid_json.json", "r") as file:
+        with open(f"{config.TEST_DATASET_PATH}dataset_invalid_json.json", "r") as file:
             dataset_invalid_json = file.read()
             file.close()
         dataset_invalid_json_filename = create_filepath("integration-test-invalid-json")
@@ -434,4 +435,4 @@ class E2EDatasetIntegrationTest(TestCase):
             key,
             value,
         ) in dataset_test_data.missing_keys_message.items():
-            assert received_messages[0][key] == value"""
+            assert received_messages[0][key] == value

--- a/src/integration_tests/datasets/e2e_dataset_integration_test.py
+++ b/src/integration_tests/datasets/e2e_dataset_integration_test.py
@@ -36,7 +36,6 @@ class E2EDatasetIntegrationTest(TestCase):
         pubsub_teardown(dataset_pubsub_helper, test_dataset_subscriber_id)
         pubsub_teardown(dataset_error_pubsub_helper, test_dataset_error_subscriber_id)
 
-
     def test_dataset_e2e(self):
         """
         Test that we can upload 2 datasets of same survey id and period and then retrieve the data.
@@ -350,7 +349,7 @@ class E2EDatasetIntegrationTest(TestCase):
             json_response.pop("dataset_id")
             assert dataset_test_data.unit_response.items() == json_response.items()
 
-    def test_dataset_errors(self):
+    def test_dataset_error_invalid_extension(self):
         """
         Test that when we upload three datasets with errors, the correct error is published to the error topic.
         This checks the cloud function works when there are errors in the dataset.
@@ -392,6 +391,10 @@ class E2EDatasetIntegrationTest(TestCase):
         ) in dataset_test_data.incorrect_file_extension_message.items():
             assert received_messages[0][key] == value
 
+    def test_dataset_error_invalid_json(self):
+        session = setup_session()
+        headers = generate_headers()
+
         # Upload dataset with invalid json
         with open(f"{config.TEST_DATASET_PATH}dataset_invalid_json.json", "r") as file:
             dataset_invalid_json = file.read()
@@ -412,6 +415,10 @@ class E2EDatasetIntegrationTest(TestCase):
             value,
         ) in dataset_test_data.invalid_json_message.items():
             assert received_messages[0][key] == value
+
+    def test_dataset_error_missing_keys(self):
+        session = setup_session()
+        headers = generate_headers()
 
         # Upload dataset with missing keys
         dataset_missing_keys = load_json(

--- a/src/integration_tests/datasets/e2e_dataset_integration_test.py
+++ b/src/integration_tests/datasets/e2e_dataset_integration_test.py
@@ -13,6 +13,7 @@ from src.integration_tests.helpers.integration_helpers import (
     pubsub_teardown,
     setup_session,
     create_dataset_as_string,
+    pubsub_flush_messages,
 )
 from src.integration_tests.helpers.pubsub_helper import (
     dataset_error_pubsub_helper,
@@ -26,17 +27,24 @@ from src.test_data.shared_test_data import (
 
 
 class E2EDatasetIntegrationTest(TestCase):
-    def setUp(self) -> None:
+    @classmethod
+    def setup_class(self) -> None:
         cleanup()
         pubsub_setup(dataset_pubsub_helper, test_dataset_subscriber_id)
         pubsub_setup(dataset_error_pubsub_helper, test_dataset_error_subscriber_id)
 
-    def tearDown(self) -> None:
+    @classmethod
+    def teardown_class(self) -> None:
         cleanup()
         pubsub_teardown(dataset_pubsub_helper, test_dataset_subscriber_id)
         pubsub_teardown(dataset_error_pubsub_helper, test_dataset_error_subscriber_id)
 
-    def test_dataset_e2e(self):
+    def tearDown(self) -> None:
+        cleanup()
+        pubsub_flush_messages(dataset_pubsub_helper, test_dataset_subscriber_id)
+        pubsub_flush_messages(dataset_error_pubsub_helper, test_dataset_error_subscriber_id)
+
+    def test_s_dataset_e2e(self):
         """
         Test that we can upload 2 datasets of same survey id and period and then retrieve the data.
         This checks the cloud function worked and the datasets are retained according to the retain flag.

--- a/src/integration_tests/datasets/e2e_dataset_integration_test.py
+++ b/src/integration_tests/datasets/e2e_dataset_integration_test.py
@@ -13,6 +13,7 @@ from src.integration_tests.helpers.integration_helpers import (
     pubsub_setup,
     pubsub_teardown,
     setup_session,
+    create_filename_error_filepath,
 )
 from src.integration_tests.helpers.pubsub_helper import (
     dataset_error_pubsub_helper,
@@ -349,3 +350,88 @@ class E2EDatasetIntegrationTest(TestCase):
 
             json_response.pop("dataset_id")
             assert dataset_test_data.unit_response.items() == json_response.items()
+
+    def test_dataset_errors(self):
+        """
+        Test that when we upload three datasets with errors, the correct error is published to the error topic.
+        This checks the cloud function works when there are errors in the dataset.
+        There are errors on 3 instances:
+        - When the dataset file extension is not json
+        - When the dataset file is not valid json
+        - When the dataset file is missing required keys
+        * We load the sample dataset json files with errors
+        * Upload the dataset files to the dataset bucket
+        * Check the files are not removed from the bucket
+        * Check the error messages are published to the error topic
+        """
+        session = setup_session()
+        headers = generate_headers()
+        # Upload dataset with invalid filename
+        dataset_incorrect_extension = load_json(
+            f"{config.TEST_DATASET_PATH}dataset.json"
+        )
+        dataset_incorrect_extension_filename = create_filename_error_filepath(
+            "integration-test-incorrect-extension"
+        )
+        create_dataset_response = create_dataset(
+            dataset_incorrect_extension_filename,
+            dataset_incorrect_extension,
+            session,
+            headers,
+            skip_wait=True,
+        )
+        if create_dataset_response is not None and create_dataset_response != 200:
+            assert False, "Unsuccessful request to create dataset"
+        # Check pubsub messages and ack
+        received_messages = dataset_error_pubsub_helper.pull_and_acknowledge_messages(
+            test_dataset_error_subscriber_id
+        )
+        for (
+            key,
+            value,
+        ) in dataset_test_data.incorrect_file_extension_message.items():
+            assert received_messages[0][key] == value
+
+        # Upload dataset with invalid json
+        """with open(f"{config.TEST_DATASET_PATH}dataset_invalid_json.json", "r") as file:
+            dataset_invalid_json = file.read()
+            file.close()
+        dataset_invalid_json_filename = create_filepath("integration-test-invalid-json")
+        create_dataset_response = create_dataset_as_string(
+            dataset_invalid_json_filename, dataset_invalid_json, session, headers
+        )
+        if create_dataset_response is not None and create_dataset_response != 200:
+            assert False, "Unsuccessful request to create dataset"
+        # Check pubsub messages and ack
+        received_messages = dataset_error_pubsub_helper.pull_and_acknowledge_messages(
+            test_dataset_error_subscriber_id
+        )
+        for (
+            key,
+            value,
+        ) in dataset_test_data.invalid_json_message.items():
+            assert received_messages[0][key] == value
+
+        # Upload dataset with missing keys
+        dataset_missing_keys = load_json(
+            f"{config.TEST_DATASET_PATH}dataset_missing_keys.json"
+        )
+        dataset_missing_keys_filename = create_filepath("integration-test-missing-keys")
+        create_dataset_response = create_dataset(
+            dataset_missing_keys_filename,
+            dataset_missing_keys,
+            session,
+            headers,
+            skip_wait=True,
+        )
+        if create_dataset_response is not None and create_dataset_response != 200:
+            assert False, "Unsuccessful request to create dataset"
+        # Check pubsub messages and ack
+        received_messages = dataset_error_pubsub_helper.pull_and_acknowledge_messages(
+            test_dataset_error_subscriber_id
+        )
+        for (
+            key,
+            value,
+        ) in dataset_test_data.missing_keys_message.items():
+            assert received_messages[0][key] == value"""

--- a/src/integration_tests/datasets/e2e_dataset_integration_test.py
+++ b/src/integration_tests/datasets/e2e_dataset_integration_test.py
@@ -13,7 +13,7 @@ from src.integration_tests.helpers.integration_helpers import (
     pubsub_teardown,
     setup_session,
     create_dataset_as_string,
-    pubsub_flush_messages,
+    pubsub_purge_messages,
 )
 from src.integration_tests.helpers.pubsub_helper import (
     dataset_error_pubsub_helper,
@@ -41,8 +41,8 @@ class E2EDatasetIntegrationTest(TestCase):
 
     def tearDown(self) -> None:
         cleanup()
-        pubsub_flush_messages(dataset_pubsub_helper, test_dataset_subscriber_id)
-        pubsub_flush_messages(dataset_error_pubsub_helper, test_dataset_error_subscriber_id)
+        pubsub_purge_messages(dataset_pubsub_helper, test_dataset_subscriber_id)
+        pubsub_purge_messages(dataset_error_pubsub_helper, test_dataset_error_subscriber_id)
 
     def test_s_dataset_e2e(self):
         """

--- a/src/integration_tests/helpers/integration_helpers.py
+++ b/src/integration_tests/helpers/integration_helpers.py
@@ -313,10 +313,21 @@ def pubsub_teardown(pubsub_helper: PubSubHelper, subscriber_id: str) -> None:
 
 
 def pubsub_purge_messages(pubsub_helper: PubSubHelper, subscriber_id: str) -> None:
-    """Purge any messages that may have been sent to a subscriber"""
-    time.sleep(5) # Wait for messages to be sent
-    
+    """Purge any messages that may have been sent to a subscriber"""   
     pubsub_helper.purge_messages(subscriber_id)
+
+
+def inject_wait_time(seconds: int) -> None:
+    """
+    Method to inject a wait time into the test to allow resources properly spin up and tear down.
+
+    Parameters:
+        seconds: the number of seconds to wait
+
+    Returns:
+        None
+    """
+    time.sleep(seconds)
 
 
 def force_run_schedule_job():

--- a/src/integration_tests/helpers/integration_helpers.py
+++ b/src/integration_tests/helpers/integration_helpers.py
@@ -309,3 +309,11 @@ def force_run_schedule_job():
         name=f"projects/{config.PROJECT_ID}/locations/europe-west2/jobs/trigger-new-dataset"
     )
     client.run_job(request=request)
+
+def create_filename_error_filepath(file_prefix: str):
+    """
+    Creates a filepath without '.json' suffix for uploading a dataset file to a bucket
+    Parameters:
+        file_prefix: prefix to identify the file being uploaded
+    """
+    return f"{file_prefix}-{str(datetime.now()).replace(' ','-')}"

--- a/src/integration_tests/helpers/integration_helpers.py
+++ b/src/integration_tests/helpers/integration_helpers.py
@@ -316,4 +316,4 @@ def create_filename_error_filepath(file_prefix: str):
     Parameters:
         file_prefix: prefix to identify the file being uploaded
     """
-    return f"{file_prefix}-{str(datetime.now()).replace(' ','-')}"
+    return f"{file_prefix}-{datetime.now().strftime(config.TIME_FORMAT).replace(' ','-')}.txt"

--- a/src/integration_tests/helpers/integration_helpers.py
+++ b/src/integration_tests/helpers/integration_helpers.py
@@ -168,6 +168,25 @@ def _create_remote_dataset(
         )
 
 
+def create_dataset_as_string(
+    filename: str, file_content: str, session: requests.Session, headers: dict[str, str]
+) -> int:
+    """
+    Method to create a remote dataset without parsing it as JSON.
+    Parameters:
+        filename: the filename to use for the file
+        file_content: the content of the file to be uploaded
+        session: a session instance for http/s connections
+        headers: the relevant headers for authentication for http/s calls
+    Returns:
+        None
+    """
+    if config.OAUTH_CLIENT_ID.__contains__("local"):
+        _create_local_dataset_as_string(session, filename, file_content)
+    else:
+        _create_remote_dataset_as_string(session, filename, file_content, headers)
+
+
 def _create_local_dataset_as_string(
     session: requests.Session, filename: str, file_content: str
 ) -> None:
@@ -309,11 +328,3 @@ def force_run_schedule_job():
         name=f"projects/{config.PROJECT_ID}/locations/europe-west2/jobs/trigger-new-dataset"
     )
     client.run_job(request=request)
-
-def create_filename_error_filepath(file_prefix: str):
-    """
-    Creates a filepath without '.json' suffix for uploading a dataset file to a bucket
-    Parameters:
-        file_prefix: prefix to identify the file being uploaded
-    """
-    return f"{file_prefix}-{datetime.now().strftime(config.TIME_FORMAT).replace(' ','-')}.txt"

--- a/src/integration_tests/helpers/integration_helpers.py
+++ b/src/integration_tests/helpers/integration_helpers.py
@@ -307,16 +307,18 @@ def pubsub_setup(pubsub_helper: PubSubHelper, subscriber_id: str) -> None:
     pubsub_helper.try_create_subscriber(subscriber_id)
 
 
-def pubsub_teardown(pubsub_helper: PubSubHelper, subscriber_id: str):
+def pubsub_teardown(pubsub_helper: PubSubHelper, subscriber_id: str) -> None:
     """Deletes subscribers that may have been used in tests"""
     pubsub_helper.try_delete_subscriber(subscriber_id)
 
 
-def empty_dataset_bucket() -> None:
-    """
-    Method to empty the dataset bucket.
-    """
-    delete_blobs(bucket_loader.get_dataset_bucket())
+def pubsub_flush_messages(pubsub_helper: PubSubHelper, subscriber_id: str) -> None:
+    """Flushes any messages that may have been sent to a subscriber"""
+    time.sleep(5) # Wait for messages to be sent
+
+    while True:
+        if not pubsub_helper.pull_and_acknowledge_messages(subscriber_id):
+            break
 
 
 def force_run_schedule_job():

--- a/src/integration_tests/helpers/integration_helpers.py
+++ b/src/integration_tests/helpers/integration_helpers.py
@@ -312,13 +312,11 @@ def pubsub_teardown(pubsub_helper: PubSubHelper, subscriber_id: str) -> None:
     pubsub_helper.try_delete_subscriber(subscriber_id)
 
 
-def pubsub_flush_messages(pubsub_helper: PubSubHelper, subscriber_id: str) -> None:
-    """Flushes any messages that may have been sent to a subscriber"""
+def pubsub_purge_messages(pubsub_helper: PubSubHelper, subscriber_id: str) -> None:
+    """Purge any messages that may have been sent to a subscriber"""
     time.sleep(5) # Wait for messages to be sent
-
-    while True:
-        if not pubsub_helper.pull_and_acknowledge_messages(subscriber_id):
-            break
+    
+    pubsub_helper.purge_messages(subscriber_id)
 
 
 def force_run_schedule_job():

--- a/src/integration_tests/helpers/pubsub_helper.py
+++ b/src/integration_tests/helpers/pubsub_helper.py
@@ -78,7 +78,7 @@ class PubSubHelper:
 
         response = self.subscriber_client.pull(
             request={"subscription": subscription_path, "max_messages": NUM_MESSAGES},
-            timeout=5.0,
+            timeout=10.0,
         )
 
         messages = []

--- a/src/integration_tests/helpers/pubsub_helper.py
+++ b/src/integration_tests/helpers/pubsub_helper.py
@@ -71,7 +71,7 @@ class PubSubHelper:
         print(f"Fail to create subscriber. Subscription path: {subscription_path}")
 
 
-    def pull_and_acknowledge_messages(self, subscriber_id: str) -> dict:
+    def pull_and_acknowledge_messages(self, subscriber_id: str) -> dict|None:
         """
         Pulls all messages published to a topic via a subscriber.
 
@@ -81,14 +81,21 @@ class PubSubHelper:
         subscription_path = self.subscriber_client.subscription_path(
             config.PROJECT_ID, subscriber_id
         )
-        NUM_MESSAGES = 5
+        NUM_MESSAGES = 1
 
         response = self.subscriber_client.pull(
             request={"subscription": subscription_path, "max_messages": NUM_MESSAGES},
         )
 
+        message_count = len(response.received_messages)
+
+        if message_count == 0:
+            print("No messages found in the response")
+            return None
+        
         messages = []
         ack_ids = []
+        
         for received_message in response.received_messages:
             messages.append(self.format_received_message_data(received_message))
             ack_ids.append(received_message.ack_id)

--- a/src/integration_tests/helpers/pubsub_helper.py
+++ b/src/integration_tests/helpers/pubsub_helper.py
@@ -81,7 +81,7 @@ class PubSubHelper:
         subscription_path = self.subscriber_client.subscription_path(
             config.PROJECT_ID, subscriber_id
         )
-        NUM_MESSAGES = 1
+        NUM_MESSAGES = 5
 
         response = self.subscriber_client.pull(
             request={"subscription": subscription_path, "max_messages": NUM_MESSAGES},
@@ -100,14 +100,27 @@ class PubSubHelper:
             messages.append(self.format_received_message_data(received_message))
             ack_ids.append(received_message.ack_id)
 
-        if ack_ids:
-            self.subscriber_client.acknowledge(
-                request={"subscription": subscription_path, "ack_ids": ack_ids}
-            )
-        else:
-            print("No Ack IDs found in the response, messages cannot be acknowledged")
+        
+        self.subscriber_client.acknowledge(
+            request={"subscription": subscription_path, "ack_ids": ack_ids}
+        )
 
         return messages
+    
+    def purge_messages(self, subscriber_id: str) -> None:
+        """
+        Purges all messages published to a subscriber by seeking through future timestamp.
+
+        Parameters:
+        subscriber_id: the unique id of the subscriber being created.
+        """
+        subscription_path = self.subscriber_client.subscription_path(
+            config.PROJECT_ID, subscriber_id
+        )
+
+        self.subscriber_client.seek(
+            request={"subscription": subscription_path, "time": "2999-01-01T00:00:00Z"}
+        )
 
     def format_received_message_data(self, received_message) -> dict:
         """

--- a/src/integration_tests/helpers/pubsub_helper.py
+++ b/src/integration_tests/helpers/pubsub_helper.py
@@ -62,7 +62,9 @@ class PubSubHelper:
                 }
             )
 
-            self._wait_and_check_subscription_exists(subscriber_id)
+        if not self._wait_and_check_subscription_exists(subscriber_id):               
+            print(f"Fail to create subscriber. Subscription path: {subscription_path}")
+
 
     def pull_and_acknowledge_messages(self, subscriber_id: str) -> dict:
         """
@@ -78,7 +80,6 @@ class PubSubHelper:
 
         response = self.subscriber_client.pull(
             request={"subscription": subscription_path, "max_messages": NUM_MESSAGES},
-            timeout=10.0,
         )
 
         messages = []
@@ -119,7 +120,9 @@ class PubSubHelper:
                     request={"subscription": subscription_path}
                 )
 
-            self._wait_and_check_subscription_deleted(subscriber_id)
+        if not self._wait_and_check_subscription_deleted(subscriber_id):
+            print(f"Fail to delete subscriber. Subscription path: {subscription_path}")
+
 
     def _subscription_exists(self, subscriber_id: str) -> None:
         """
@@ -145,7 +148,7 @@ class PubSubHelper:
         subscriber_id: str,
         attempts: int = 5,
         backoff: int = 0.5,
-    ) -> None:
+    ) -> bool:
         """
         Waits for a subscription to be created and checks if it exists.
 
@@ -156,18 +159,20 @@ class PubSubHelper:
         """
         while attempts != 0:
             if self._subscription_exists(subscriber_id):
-                return
+                return True
 
             attempts -= 1
             time.sleep(backoff)
             backoff += backoff
+
+        return False
 
     def _wait_and_check_subscription_deleted(
         self,
         subscriber_id: str,
         attempts: int = 5,
         backoff: int = 0.5,
-    ) -> None:
+    ) -> bool:
         """
         Waits for a subscription to be created and checks if it is deleted.
 
@@ -178,11 +183,13 @@ class PubSubHelper:
         """
         while attempts != 0:
             if not self._subscription_exists(subscriber_id):
-                return
+                return True
 
             attempts -= 1
             time.sleep(backoff)
             backoff += backoff
+
+        return False
 
 
 dataset_pubsub_helper = PubSubHelper(config.PUBLISH_DATASET_TOPIC_ID)

--- a/src/integration_tests/schemas/e2e_schema_integration_test.py
+++ b/src/integration_tests/schemas/e2e_schema_integration_test.py
@@ -8,6 +8,8 @@ from src.integration_tests.helpers.integration_helpers import (
     pubsub_setup,
     pubsub_teardown,
     setup_session,
+    pubsub_purge_messages,
+    inject_wait_time,
 )
 from src.integration_tests.helpers.pubsub_helper import schema_pubsub_helper
 from src.test_data.schema_test_data import test_survey_id, test_survey_id_map
@@ -15,13 +17,21 @@ from src.test_data.shared_test_data import test_schema_subscriber_id
 
 
 class E2ESchemaIntegrationTest(TestCase):
-    def setUp(self) -> None:
+    @classmethod
+    def setup_class(self) -> None:
         cleanup()
         pubsub_setup(schema_pubsub_helper, test_schema_subscriber_id)
+        inject_wait_time(3) # Inject wait time to allow resources properly set up
+
+    @classmethod
+    def teardown_class(self) -> None:
+        cleanup()
+        pubsub_teardown(schema_pubsub_helper, test_schema_subscriber_id)
 
     def tearDown(self) -> None:
         cleanup()
-        pubsub_teardown(schema_pubsub_helper, test_schema_subscriber_id)
+        inject_wait_time(3) # Inject wait time to allow all message to be processed
+        pubsub_purge_messages(schema_pubsub_helper, test_schema_subscriber_id)
 
     def test_schema_e2e(self):
         """


### PR DESCRIPTION
### Motivation and Context
Bug exist in integration test, specifically for dataset error integration tests. This PR is to resolve the issue alongside some intermittent bugs

### What has changed
- To avoid error saying message acknowledgement has an invalid ack id, the integration test will only spin up subscription channel at the beginning of each test class and tear down after all tests are run within the class. This is due to the error comes from reusing the same subscription channel name but programmatically creating and destroying it, causing a confusion in ack id. To accommodate such mechanism, message in subscription channels will be purged after each test using the `seek` method pointing to a future timestamp, causing all unacknowledged message to be instantly acknowledged.
- To avoid error saying 404 resource not found (on the subscription channel), 5 attempts are given to create the subscription channel, while each attempt has already got a wait mechanism with backoff to recursively check for existence of the channels. As error continue to intermittently occur after the change, a wait time is inserted after confirming the channel exist to further moderate it. Same logic is implemented when deleting subscription channel.

### How to test?
Pass integration tests in all pipelines

### Links
https://jira.ons.gov.uk/browse/SDSS-846

### Screenshots (if appropriate):