### PR TITLE
Sdss 848 dataset happy path

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.109.2
+fastapi==0.115.2
 uvicorn===0.21.1
 gunicorn==22.0.0
 pytest==7.2.2

--- a/src/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/src/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -12,6 +12,7 @@ from src.integration_tests.helpers.integration_helpers import (
 )
 from src.integration_tests.helpers.firestore_helpers import upload_dataset
 from google.cloud import firestore
+import logging
 
 class DatasetEndpointsIntegrationTest(TestCase):
     session = None
@@ -51,7 +52,28 @@ class DatasetEndpointsIntegrationTest(TestCase):
         """
         """
 
-        assert self.dataset is not None, "first dataset upload failed"
+        response = self.session.get(
+            f"{config.API_URL}/v1/dataset_metadata?survey_id=test_survey_id&period_id=test_period_id_2",
+            headers = self.headers
+        )
+
+        assert self.dataset is not None, "Dataset upload failed"
+        assert response.status_code == 200, "not found"
+
+        metadata_data = response.json()
+
+        assert metadata_data == [{
+        "dataset_id": "3",
+        "survey_id": "test_survey_id",
+        "period_id": "test_period_id_2",
+        "form_types": ["knj", "okn", "ojdw"],
+        "title": "Which side was better?",
+        "sds_published_at": "2023-04-20T12:00:00Z",
+        "total_reporting_units": 2,
+        "schema_version": "v1.0.0",
+        "sds_dataset_version": 1,
+        "filename": "test_filename.json",
+        } ]
 
     @pytest.mark.order(2)
     def test_grabbing_unit_data(self):
@@ -74,24 +96,35 @@ class DatasetEndpointsIntegrationTest(TestCase):
         "schema_version": "v1.0.0",
         "form_types": ["jke", "als", "sma"],
         "data": "test",
-    }
+        }
 
-    # @pytest.mark.order()
-    # def test_dataset_without_title(self):
-    #     """
-    #     """
+    @pytest.mark.order(3)
+    def test_dataset_without_title(self):
+        """
+        """
 
-    
-    # @pytest.mark.order()
-    # def test_dataset_with_different_period_id(self):
-    #     """
-    #     """
+        response = self.session.get(
+            f"{config.API_URL}/v1/dataset_metadata?survey_id=test_survey_id&period_id=test_period_id",
+            headers = self.headers
+        )
+
+        assert response.status_code == 200, "not found"
+
+        metadata_without_title = response.json()
+
+        assert metadata_without_title == [{
+        "dataset_id": "1",
+        "survey_id": "test_survey_id",
+        "period_id": "test_period_id",
+        "form_types": ["oas", "alm", "lma"],
+        "sds_published_at": "2023-04-20T12:00:00Z",
+        "total_reporting_units": 2,
+        "schema_version": "v1.0.0",
+        "sds_dataset_version": 1,
+        "filename": "test_filename.json",
+        }]
 
 
-    # @pytest.mark.order()
-    # def test_dataset_with_different_period_id(self):
-    #     """
-    #     """
 
     
 

--- a/src/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/src/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -49,15 +49,15 @@ class DatasetEndpointsIntegrationTest(TestCase):
         """
 
         response = self.session.get(
-            f"{config.API_URL}/v1/dataset_metadata?survey_id=test_survey_id_1&period_id=test_period_id",
+            f"{config.API_URL}/v1/dataset_metadata?survey_id=test_survey_id_1&period_id=test_period_id_1",
             headers = self.headers
         )
 
         assert response.status_code == 200
 
-        metadata_data = response.json() 
+        expected_metadata = dataset_metadata_collection_endpoints[0]
 
-        assert metadata_data[0] == dataset_metadata_collection_endpoints[0]
+        assert response.json() == [expected_metadata]
 
 
 
@@ -92,13 +92,13 @@ class DatasetEndpointsIntegrationTest(TestCase):
         """
 
         response = self.session.get(
-            f"{config.API_URL}/v1/dataset_metadata?survey_id=test_survey_id_2&period_id=test_period_id",
+            f"{config.API_URL}/v1/dataset_metadata?survey_id=test_survey_id_2&period_id=test_period_id_2",
             headers = self.headers
         )
 
         assert response.status_code == 200
 
-        metadata_without_title = response.json()
+        expected_metadata_without_title =  dataset_metadata_collection_endpoints[1]
 
-        assert metadata_without_title[0] == dataset_metadata_collection_endpoints[1]
+        assert response.json() == [expected_metadata_without_title]
         

--- a/src/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/src/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -17,14 +17,7 @@ import logging
 class DatasetEndpointsIntegrationTest(TestCase):
     session = None
     headers = None
-    first_dataset = None
-    second_dataset = None
     firestore_client = None
-    dataset_without_title = None
-    dataset_different_period_id = None
-    # 3 datasets - 2 with same survey n period id. 1 with same survey id but different period id
-    # each dataset more than 1 unit data (2)...
-    #
     
     @classmethod
     def setup_class(self) -> None:
@@ -34,18 +27,12 @@ class DatasetEndpointsIntegrationTest(TestCase):
         self.headers = generate_headers()
         self.firestore_client = firestore.Client(project=config.PROJECT_ID, database=f"{config.PROJECT_ID}-sds")
         self.dataset = upload_dataset(self.firestore_client, dataset_metadata_collection_endpoints, dataset_unit_data_collection_endpoints)
-        # self.second_dataset = upload_dataset(self.firestore_client, dataset_metadata_collection_endpoints[1], dataset_unit_data_collection_endpoints)
-        # self.dataset_without_title = upload_dataset(self.firestore_client, [dataset_metadata_collection[2]], dataset_unit_data_collection)
-        # self.dataset_different_period_id = upload_dataset(self.firestore_client, [dataset_metadata_collection[3]], dataset_unit_data_collection)
         
 
     @classmethod
     def teardown_class(self) -> None:
-        # cleanup()
+        cleanup()
         inject_wait_time(3) # Inject wait time to allow all message to be processed
-    
-
-    # method for grabbing unit data, dataset metadata and uploading 3 but return 2 wth same survey id
 
     @pytest.mark.order(1)
     def test_dataset_upload_and_metadata(self):

--- a/src/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/src/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -99,17 +99,18 @@ class DatasetEndpointsIntegrationTest(TestCase):
 
         metadata_without_title = response.json()
 
-        assert metadata_without_title == [{
-        "dataset_id": "1",
+        assert metadata_without_title[1] == {
+        "dataset_id": "2",
         "survey_id": "test_survey_id",
         "period_id": "test_period_id",
         "form_types": ["oas", "alm", "lma"],
+        "title": None,
         "sds_published_at": "2023-04-20T12:00:00Z",
         "total_reporting_units": 2,
         "schema_version": "v1.0.0",
         "sds_dataset_version": 1,
         "filename": "test_filename.json",
-        }]
+        }
 
 
 

--- a/src/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/src/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -32,7 +32,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
         inject_wait_time(3) # Inject wait time to allow resources properly set up
         self.session = setup_session()
         self.headers = generate_headers()
-        self.firestore_client = firestore.Client(project=config.PROJECT_ID, database=f"{config.PROJECT_ID}-sds")
+        self.firestore_client = firestore.Client(project=config.PROJECT_ID, database=config.FIRESTORE_DB_NAME)
         self.dataset = upload_dataset(self.firestore_client, dataset_metadata_collection_for_endpoints_test, dataset_unit_data_collection_for_endpoints_test)
         
 

--- a/src/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/src/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -2,8 +2,8 @@ import pytest
 from unittest import TestCase
 from src.app.config.config_factory import config
 from src.test_data.dataset_test_data import ( 
-    dataset_metadata_collection_endpoints, 
-    dataset_unit_data_collection_endpoints 
+    dataset_metadata_collection_for_endpoints_test, 
+    dataset_unit_data_collection_for_endpoints_test 
 )
 from repositories.firebase.firebase_loader import firebase_loader
 from src.integration_tests.helpers.integration_helpers import (
@@ -33,7 +33,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
         self.session = setup_session()
         self.headers = generate_headers()
         self.firestore_client = firestore.Client(project=config.PROJECT_ID, database=f"{config.PROJECT_ID}-sds")
-        self.dataset = upload_dataset(self.firestore_client, dataset_metadata_collection_endpoints, dataset_unit_data_collection_endpoints)
+        self.dataset = upload_dataset(self.firestore_client, dataset_metadata_collection_for_endpoints_test, dataset_unit_data_collection_for_endpoints_test)
         
 
     @classmethod
@@ -57,7 +57,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
         
         expected_data = [
             {
-                **dataset_metadata_collection_endpoints[0],
+                **dataset_metadata_collection_for_endpoints_test[0],
             }
         ]
 
@@ -81,7 +81,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
         )
 
         assert response.status_code == 200
-        assert response.json() == dataset_unit_data_collection_endpoints[0]
+        assert response.json() == dataset_unit_data_collection_for_endpoints_test[0]
 
     @pytest.mark.order(3)
     def test_dataset_without_title(self):
@@ -100,7 +100,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
 
         expected_data = [
             {
-                **dataset_metadata_collection_endpoints[1],
+                **dataset_metadata_collection_for_endpoints_test[1],
             }
         ]
 

--- a/src/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/src/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -41,7 +41,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
         inject_wait_time(3) # Inject wait time to allow all message to be processed
 
     @pytest.mark.order(1)
-    def test_dataset_upload_and_metadata(self):
+    def get_dataset_metadata_collection(self):
         """
         Test uploading and retriving dataset metadata.
 
@@ -55,8 +55,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
             headers = self.headers
         )
 
-        assert self.dataset is not None, "Dataset upload failed"
-        assert response.status_code == 200, "not found"
+        assert response.status_code == 200, "Error, no dataset found"
 
         metadata_data = response.json()
 
@@ -74,7 +73,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
         } ]
 
     @pytest.mark.order(2)
-    def test_grabbing_unit_data(self):
+    def get_dataset_unit_supplementary_data(self):
         """
         Test retrieving unit data for a dataset
 
@@ -88,7 +87,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
             headers = self.headers
         )
 
-        assert response.status_code == 200, "not found"
+        assert response.status_code == 200, "Error, no unit data found"
 
         unit_data = response.json()
 

--- a/src/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/src/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -12,14 +12,13 @@ from src.integration_tests.helpers.integration_helpers import (
 )
 from src.integration_tests.helpers.firestore_helpers import upload_dataset
 from google.cloud import firestore
-import logging
 
 class DatasetEndpointsIntegrationTest(TestCase):
     """
     Integration tests for the Dataset Endpoints.
 
-    This test covers uploading datasets, fetching metdata and unit data from firestore,
-    and checking that dataset metadata is handled correctly.
+    This test covers fetching metdata and unit data from firestore,
+    and checking that dataset metadata and unit data is handled correctly.
     """
     session = None
     headers = None
@@ -41,64 +40,46 @@ class DatasetEndpointsIntegrationTest(TestCase):
         inject_wait_time(3) # Inject wait time to allow all message to be processed
 
     @pytest.mark.order(1)
-    def get_dataset_metadata_collection(self):
+    def test_get_dataset_metadata_collection(self):
         """
-        Test uploading and retriving dataset metadata.
+        Test retriving dataset metadata.
 
         - Sends a GET request to retrieve metadata for a dataset
-        - Verifies that the dataset was uploaded successfully
         - Asserts the metadata retrieved matches the expected structure.
         """
 
         response = self.session.get(
-            f"{config.API_URL}/v1/dataset_metadata?survey_id=test_survey_id&period_id=test_period_id_2",
+            f"{config.API_URL}/v1/dataset_metadata?survey_id=test_survey_id_1&period_id=test_period_id",
             headers = self.headers
         )
 
-        assert response.status_code == 200, "Error, no dataset found"
+        assert response.status_code == 200
 
-        metadata_data = response.json()
+        metadata_data = response.json() 
 
-        assert metadata_data == [{
-        "dataset_id": "3",
-        "survey_id": "test_survey_id",
-        "period_id": "test_period_id_2",
-        "form_types": ["knj", "okn", "ojdw"],
-        "title": "Which side was better?",
-        "sds_published_at": "2023-04-20T12:00:00Z",
-        "total_reporting_units": 2,
-        "schema_version": "v1.0.0",
-        "sds_dataset_version": 1,
-        "filename": "test_filename.json",
-        } ]
+        assert dataset_metadata_collection_endpoints[0] in metadata_data
+
+
 
     @pytest.mark.order(2)
-    def get_dataset_unit_supplementary_data(self):
+    def test_get_dataset_unit_supplementary_data(self):
         """
         Test retrieving unit data for a dataset
 
         - Get request to retrieve unit data for a dataset
-        - Asserts the status code, if its found (200) or not (404)
         - Asserts if unit data matches the expected structure
         """
 
         response = self.session.get(
-            f"{config.API_URL}/v1/unit_data?dataset_id=0&identifier=43532",
+            f"{config.API_URL}/v1/unit_data?dataset_id=1&identifier=43532",
             headers = self.headers
         )
 
-        assert response.status_code == 200, "Error, no unit data found"
+        assert response.status_code == 200
 
         unit_data = response.json()
 
-        assert unit_data == {
-        "dataset_id": "0",
-        "survey_id": "test_survey_id",
-        "period_id": "test_period_id",
-        "schema_version": "v1.0.0",
-        "form_types": ["jke", "als", "sma"],
-        "data": "test",
-        }
+        assert unit_data in dataset_unit_data_collection_endpoints 
 
     @pytest.mark.order(3)
     def test_dataset_without_title(self):
@@ -111,24 +92,13 @@ class DatasetEndpointsIntegrationTest(TestCase):
         """
 
         response = self.session.get(
-            f"{config.API_URL}/v1/dataset_metadata?survey_id=test_survey_id&period_id=test_period_id",
+            f"{config.API_URL}/v1/dataset_metadata?survey_id=test_survey_id_2&period_id=test_period_id",
             headers = self.headers
         )
 
-        assert response.status_code == 200, "not found"
+        assert response.status_code == 200
 
         metadata_without_title = response.json()
 
-        assert metadata_without_title[1] == {
-        "dataset_id": "2",
-        "survey_id": "test_survey_id",
-        "period_id": "test_period_id",
-        "form_types": ["oas", "alm", "lma"],
-        "title": None,
-        "sds_published_at": "2023-04-20T12:00:00Z",
-        "total_reporting_units": 2,
-        "schema_version": "v1.0.0",
-        "sds_dataset_version": 1,
-        "filename": "test_filename.json",
-        }
+        assert dataset_metadata_collection_endpoints[1] in metadata_without_title
         

--- a/src/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/src/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -51,7 +51,9 @@ class DatasetEndpointsIntegrationTest(TestCase):
         """
 
         response = self.session.get(
-            f"{config.API_URL}/v1/dataset_metadata?survey_id=test_survey_id_1&period_id=test_period_id_1",
+            f"{config.API_URL}/v1/dataset_metadata?"
+            f"survey_id={dataset_metadata_collection_for_endpoints_test[0]['survey_id']}&"
+            f"period_id={dataset_metadata_collection_for_endpoints_test[0]['period_id']}",
             headers = self.headers
         )
         
@@ -76,7 +78,8 @@ class DatasetEndpointsIntegrationTest(TestCase):
         """
 
         response = self.session.get(
-            f"{config.API_URL}/v1/unit_data?dataset_id=1&identifier=43532",
+            f"{config.API_URL}/v1/unit_data?"
+            f"dataset_id={dataset_unit_data_collection_for_endpoints_test[0]['dataset_id']}&identifier=43532",
             headers = self.headers
         )
 
@@ -94,7 +97,9 @@ class DatasetEndpointsIntegrationTest(TestCase):
         """
 
         response = self.session.get(
-            f"{config.API_URL}/v1/dataset_metadata?survey_id=test_survey_id_2&period_id=test_period_id_2",
+            f"{config.API_URL}/v1/dataset_metadata?"
+            f"survey_id={dataset_metadata_collection_for_endpoints_test[1]['survey_id']}&"
+            f"period_id={dataset_metadata_collection_for_endpoints_test[1]['period_id']}",
             headers = self.headers
         )
 

--- a/src/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/src/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -1,8 +1,10 @@
 import pytest
 from unittest import TestCase
 from src.app.config.config_factory import config
-from src.test_data.dataset_test_data import dataset_metadata_collection_endpoints
-from src.test_data.dataset_test_data import dataset_unit_data_collection_endpoints
+from src.test_data.dataset_test_data import ( 
+    dataset_metadata_collection_endpoints, 
+    dataset_unit_data_collection_endpoints 
+)
 from repositories.firebase.firebase_loader import firebase_loader
 from src.integration_tests.helpers.integration_helpers import (
     cleanup,

--- a/src/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/src/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -55,9 +55,13 @@ class DatasetEndpointsIntegrationTest(TestCase):
 
         assert response.status_code == 200
 
-        expected_metadata = dataset_metadata_collection_endpoints[0]
+        expected_data = [
+            {
+                **dataset_metadata_collection_endpoints[0],
+            }
+        ]
 
-        assert response.json() == [expected_metadata]
+        assert response.json() == expected_data
 
 
 
@@ -77,9 +81,8 @@ class DatasetEndpointsIntegrationTest(TestCase):
 
         assert response.status_code == 200
 
-        unit_data = response.json()
 
-        assert unit_data in dataset_unit_data_collection_endpoints 
+        assert response.json() == dataset_unit_data_collection_endpoints[0]
 
     @pytest.mark.order(3)
     def test_dataset_without_title(self):
@@ -98,7 +101,11 @@ class DatasetEndpointsIntegrationTest(TestCase):
 
         assert response.status_code == 200
 
-        expected_metadata_without_title =  dataset_metadata_collection_endpoints[1]
+        expected_data = [
+            {
+                **dataset_metadata_collection_endpoints[1],
+            }
+        ]
 
-        assert response.json() == [expected_metadata_without_title]
+        assert response.json() == expected_data
         

--- a/src/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/src/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -52,15 +52,14 @@ class DatasetEndpointsIntegrationTest(TestCase):
             f"{config.API_URL}/v1/dataset_metadata?survey_id=test_survey_id_1&period_id=test_period_id_1",
             headers = self.headers
         )
-
-        assert response.status_code == 200
-
+        
         expected_data = [
             {
                 **dataset_metadata_collection_endpoints[0],
             }
         ]
 
+        assert response.status_code == 200
         assert response.json() == expected_data
 
 
@@ -80,8 +79,6 @@ class DatasetEndpointsIntegrationTest(TestCase):
         )
 
         assert response.status_code == 200
-
-
         assert response.json() == dataset_unit_data_collection_endpoints[0]
 
     @pytest.mark.order(3)
@@ -99,13 +96,12 @@ class DatasetEndpointsIntegrationTest(TestCase):
             headers = self.headers
         )
 
-        assert response.status_code == 200
-
         expected_data = [
             {
                 **dataset_metadata_collection_endpoints[1],
             }
         ]
 
+        assert response.status_code == 200
         assert response.json() == expected_data
         

--- a/src/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/src/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -39,7 +39,6 @@ class DatasetEndpointsIntegrationTest(TestCase):
     @classmethod
     def teardown_class(self) -> None:
         cleanup()
-        inject_wait_time(3) # Inject wait time to allow all message to be processed
 
     @pytest.mark.order(1)
     def test_get_dataset_metadata_collection(self):

--- a/src/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/src/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -1,0 +1,100 @@
+import pytest
+from unittest import TestCase
+from src.app.config.config_factory import config
+from src.test_data.dataset_test_data import dataset_metadata_collection_endpoints
+from src.test_data.dataset_test_data import dataset_unit_data_collection_endpoints
+from repositories.firebase.firebase_loader import firebase_loader
+from src.integration_tests.helpers.integration_helpers import (
+    cleanup,
+    generate_headers,
+    setup_session,
+    inject_wait_time,
+)
+from src.integration_tests.helpers.firestore_helpers import upload_dataset
+from google.cloud import firestore
+
+class DatasetEndpointsIntegrationTest(TestCase):
+    session = None
+    headers = None
+    first_dataset = None
+    second_dataset = None
+    firestore_client = None
+    dataset_without_title = None
+    dataset_different_period_id = None
+    # 3 datasets - 2 with same survey n period id. 1 with same survey id but different period id
+    # each dataset more than 1 unit data (2)...
+    #
+    
+    @classmethod
+    def setup_class(self) -> None:
+        cleanup()
+        inject_wait_time(3) # Inject wait time to allow resources properly set up
+        self.session = setup_session()
+        self.headers = generate_headers()
+        self.firestore_client = firestore.Client(project=config.PROJECT_ID, database=f"{config.PROJECT_ID}-sds")
+        self.dataset = upload_dataset(self.firestore_client, dataset_metadata_collection_endpoints, dataset_unit_data_collection_endpoints)
+        # self.second_dataset = upload_dataset(self.firestore_client, dataset_metadata_collection_endpoints[1], dataset_unit_data_collection_endpoints)
+        # self.dataset_without_title = upload_dataset(self.firestore_client, [dataset_metadata_collection[2]], dataset_unit_data_collection)
+        # self.dataset_different_period_id = upload_dataset(self.firestore_client, [dataset_metadata_collection[3]], dataset_unit_data_collection)
+        
+
+    @classmethod
+    def teardown_class(self) -> None:
+        # cleanup()
+        inject_wait_time(3) # Inject wait time to allow all message to be processed
+    
+
+    # method for grabbing unit data, dataset metadata and uploading 3 but return 2 wth same survey id
+
+    @pytest.mark.order(1)
+    def test_dataset_upload_and_metadata(self):
+        """
+        """
+
+        assert self.dataset is not None, "first dataset upload failed"
+
+    @pytest.mark.order(2)
+    def test_grabbing_unit_data(self):
+        """
+        """
+
+        response = self.session.get(
+            f"{config.API_URL}/v1/unit_data?dataset_id=0&identifier=43532",
+            headers = self.headers
+        )
+
+        assert response.status_code == 200, "not found"
+
+        unit_data = response.json()
+
+        assert unit_data == {
+        "dataset_id": "0",
+        "survey_id": "test_survey_id",
+        "period_id": "test_period_id",
+        "schema_version": "v1.0.0",
+        "form_types": ["jke", "als", "sma"],
+        "data": "test",
+    }
+
+    # @pytest.mark.order()
+    # def test_dataset_without_title(self):
+    #     """
+    #     """
+
+    
+    # @pytest.mark.order()
+    # def test_dataset_with_different_period_id(self):
+    #     """
+    #     """
+
+
+    # @pytest.mark.order()
+    # def test_dataset_with_different_period_id(self):
+    #     """
+    #     """
+
+    
+
+
+
+

--- a/src/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/src/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -3,7 +3,8 @@ from unittest import TestCase
 from src.app.config.config_factory import config
 from src.test_data.dataset_test_data import ( 
     dataset_metadata_collection_for_endpoints_test, 
-    dataset_unit_data_collection_for_endpoints_test 
+    dataset_unit_data_collection_for_endpoints_test,
+    dataset_unit_data_id
 )
 from repositories.firebase.firebase_loader import firebase_loader
 from src.integration_tests.helpers.integration_helpers import (
@@ -78,7 +79,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
 
         response = self.session.get(
             f"{config.API_URL}/v1/unit_data?"
-            f"dataset_id={dataset_unit_data_collection_for_endpoints_test[0]['dataset_id']}&identifier=43532",
+            f"dataset_id={dataset_unit_data_collection_for_endpoints_test[0]['dataset_id']}&identifier={dataset_unit_data_id[0]}",
             headers = self.headers
         )
 

--- a/src/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/src/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -57,7 +57,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
 
         metadata_data = response.json() 
 
-        assert dataset_metadata_collection_endpoints[0] in metadata_data
+        assert metadata_data[0] == dataset_metadata_collection_endpoints[0]
 
 
 
@@ -100,5 +100,5 @@ class DatasetEndpointsIntegrationTest(TestCase):
 
         metadata_without_title = response.json()
 
-        assert dataset_metadata_collection_endpoints[1] in metadata_without_title
+        assert metadata_without_title[0] == dataset_metadata_collection_endpoints[1]
         

--- a/src/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/src/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -15,6 +15,12 @@ from google.cloud import firestore
 import logging
 
 class DatasetEndpointsIntegrationTest(TestCase):
+    """
+    Integration tests for the Dataset Endpoints.
+
+    This test covers uploading datasets, fetching metdata and unit data from firestore,
+    and checking that dataset metadata is handled correctly.
+    """
     session = None
     headers = None
     firestore_client = None
@@ -37,6 +43,11 @@ class DatasetEndpointsIntegrationTest(TestCase):
     @pytest.mark.order(1)
     def test_dataset_upload_and_metadata(self):
         """
+        Test uploading and retriving dataset metadata.
+
+        - Sends a GET request to retrieve metadata for a dataset
+        - Verifies that the dataset was uploaded successfully
+        - Asserts the metadata retrieved matches the expected structure.
         """
 
         response = self.session.get(
@@ -65,6 +76,11 @@ class DatasetEndpointsIntegrationTest(TestCase):
     @pytest.mark.order(2)
     def test_grabbing_unit_data(self):
         """
+        Test retrieving unit data for a dataset
+
+        - Get request to retrieve unit data for a dataset
+        - Asserts the status code, if its found (200) or not (404)
+        - Asserts if unit data matches the expected structure
         """
 
         response = self.session.get(
@@ -88,6 +104,11 @@ class DatasetEndpointsIntegrationTest(TestCase):
     @pytest.mark.order(3)
     def test_dataset_without_title(self):
         """
+        Test retrieving a dataset metadata without a title
+
+        - Get request to retrieve a metadata missing a title
+        - Assert status code is 200
+        - Checks if the metadata matches the expected structure without a title
         """
 
         response = self.session.get(
@@ -111,11 +132,4 @@ class DatasetEndpointsIntegrationTest(TestCase):
         "sds_dataset_version": 1,
         "filename": "test_filename.json",
         }
-
-
-
-    
-
-
-
-
+        

--- a/src/integration_tests/helpers/firestore_helpers.py
+++ b/src/integration_tests/helpers/firestore_helpers.py
@@ -1,6 +1,17 @@
 import requests
 from config.config_factory import config
 from firebase_admin import firestore
+from services.dataset.dataset_writer_service import DatasetWriterService
+from repositories.firebase.dataset_firebase_repository import DatasetFirebaseRepository
+from services.dataset.dataset_processor_service import DatasetProcessorService
+from models.dataset_models import RawDataset
+import uuid
+from logging_config import logging
+# from src.test_data.dataset_test_data import dataset_metadata_collection, 
+# from src.test_data.dataset_test_data import dataset_unit_data_collection
+# from src.test_data.dataset_test_data import dataset_unit_data_id
+from src.test_data.dataset_test_data import dataset_metadata_collection, dataset_unit_data_collection, dataset_unit_data_id
+
 
 
 def perform_delete_on_collection_with_test_survey_id(
@@ -88,3 +99,32 @@ def delete_local_firestore_data():
     requests.delete(
         f"http://localhost:8080/emulator/v1/projects/{config.PROJECT_ID}/databases/(default)/documents"
     )
+
+def upload_dataset(firestore_client, metadata_collection, unit_data_collection):
+    """
+    Helper function to upload a dataset 
+    """
+    # firestore_client = firestore.Client(project=project_id, database=f"{project_id}-sds")
+    dataset_collection = firestore_client.collection("datasets")
+    uploaded_dataset = []
+
+    for index, dataset_metadata in enumerate(metadata_collection):
+        document_id = str(index)
+
+        dataset_collection.document(document_id).set(dataset_metadata)
+
+        unit_collection = dataset_collection.document(document_id).collection("units")
+
+        for index, unit_data in enumerate(unit_data_collection):
+            unit_document_id = dataset_unit_data_id[index] 
+            unit_data["dataset_id"] =  document_id
+            unit_collection.document(unit_document_id).set(unit_data)
+    
+        uploaded_dataset.append(dataset_metadata)
+    
+    return uploaded_dataset
+
+
+
+
+

--- a/src/integration_tests/helpers/firestore_helpers.py
+++ b/src/integration_tests/helpers/firestore_helpers.py
@@ -9,8 +9,6 @@ import uuid
 from logging_config import logging
 from src.test_data.dataset_test_data import dataset_metadata_collection, dataset_unit_data_collection, dataset_unit_data_id
 
-
-
 def perform_delete_on_collection_with_test_survey_id(
     client: firestore.Client, collection_ref: firestore.CollectionReference, test_survey_id: str
 ) -> None:
@@ -119,8 +117,3 @@ def upload_dataset(firestore_client, metadata_collection, unit_data_collection):
         uploaded_dataset.append(dataset_metadata)
     
     return uploaded_dataset
-
-
-
-
-

--- a/src/integration_tests/helpers/firestore_helpers.py
+++ b/src/integration_tests/helpers/firestore_helpers.py
@@ -7,9 +7,6 @@ from services.dataset.dataset_processor_service import DatasetProcessorService
 from models.dataset_models import RawDataset
 import uuid
 from logging_config import logging
-# from src.test_data.dataset_test_data import dataset_metadata_collection, 
-# from src.test_data.dataset_test_data import dataset_unit_data_collection
-# from src.test_data.dataset_test_data import dataset_unit_data_id
 from src.test_data.dataset_test_data import dataset_metadata_collection, dataset_unit_data_collection, dataset_unit_data_id
 
 
@@ -104,7 +101,6 @@ def upload_dataset(firestore_client, metadata_collection, unit_data_collection):
     """
     Helper function to upload a dataset 
     """
-    # firestore_client = firestore.Client(project=project_id, database=f"{project_id}-sds")
     dataset_collection = firestore_client.collection("datasets")
     uploaded_dataset = []
 

--- a/src/test_data/dataset_test_data.py
+++ b/src/test_data/dataset_test_data.py
@@ -106,11 +106,11 @@ dataset_metadata_collection_endpoints: list[DatasetMetadata] = [
         "filename": "test_filename.json",
     },
     {
-         "dataset_id": "0",
+         "dataset_id": "1",
         "survey_id": f"{test_survey_id}_2",
         "period_id": test_period_id,
         "form_types": ["390", "219", "12O"],
-        "title": "Which side was better?",
+        "title": None,
         "sds_published_at": "2023-04-20T12:00:00Z",
         "total_reporting_units": 2,
         "schema_version": "v1.0.0",

--- a/src/test_data/dataset_test_data.py
+++ b/src/test_data/dataset_test_data.py
@@ -1,7 +1,7 @@
 from models.collection_exericise_end_data import CollectionExerciseEndData
 from models.dataset_models import DatasetMetadata, DatasetMetadataWithoutId, UnitDataset
 
-from src.test_data.shared_test_data import test_guid, test_survey_id, test_period_id, test_period_id_2
+from src.test_data.shared_test_data import test_guid, test_survey_id, test_period_id
 
 """
 Local variables:

--- a/src/test_data/dataset_test_data.py
+++ b/src/test_data/dataset_test_data.py
@@ -96,7 +96,7 @@ dataset_metadata_collection_endpoints: list[DatasetMetadata] = [
     {
         "dataset_id": "0",
         "survey_id": f"{test_survey_id}_1",
-        "period_id": test_period_id,
+        "period_id": f"{test_period_id}_1",
         "form_types": ["sda", "ajk", "iwu"],
         "title": "Which side was better?",
         "sds_published_at": "2023-04-20T12:00:00Z",
@@ -108,7 +108,7 @@ dataset_metadata_collection_endpoints: list[DatasetMetadata] = [
     {
         "dataset_id": "1",
         "survey_id": f"{test_survey_id}_2",
-        "period_id": test_period_id,
+        "period_id": f"{test_period_id}_2",
         "form_types": ["390", "219", "12O"],
         "title": None,
         "sds_published_at": "2023-04-20T12:00:00Z",

--- a/src/test_data/dataset_test_data.py
+++ b/src/test_data/dataset_test_data.py
@@ -1,7 +1,7 @@
 from models.collection_exericise_end_data import CollectionExerciseEndData
 from models.dataset_models import DatasetMetadata, DatasetMetadataWithoutId, UnitDataset
 
-from src.test_data.shared_test_data import test_guid, test_survey_id, test_period_id
+from src.test_data.shared_test_data import test_guid, test_survey_id, test_period_id, test_period_id_2
 
 """
 Local variables:
@@ -13,6 +13,8 @@ updated_dataset_version = 2
 """
 Test data:
 """
+
+
 
 # unit test - dataset - test data
 string_cat = "cat"
@@ -30,6 +32,9 @@ int_identifier = "43532"
 
 # unit tests - cloud new dataset - test data
 dataset_unit_data_identifier: list[str] = ["43532", "65871"]
+
+# integration test tests - dataset - test data
+dataset_unit_data_id: list[str] = ["43532", "65871"]
 
 # unit tests - service - test data
 test_data_collection_end: CollectionExerciseEndData = CollectionExerciseEndData(
@@ -85,6 +90,53 @@ dataset_metadata_updated_version: DatasetMetadata = {
     "sds_dataset_version": updated_dataset_version,
     "filename": "test_filename.json",
 }
+
+# integration test - datasets - test data
+dataset_metadata_collection_endpoints: list[DatasetMetadata] = [
+    {
+        "survey_id": test_survey_id,
+        "period_id": test_period_id,
+        "form_types": ["sda", "ajk", "iwu"],
+        "title": "Which side was better?",
+        "sds_published_at": "2023-04-20T12:00:00Z",
+        "total_reporting_units": 2,
+        "schema_version": "v1.0.0",
+        "sds_dataset_version": first_dataset_version,
+        "filename": "test_filename.json",
+    },
+    {
+        "survey_id": test_survey_id,
+        "period_id": test_period_id,
+        "form_types": ["390", "219", "12O"],
+        "title": "Which side was better?",
+        "sds_published_at": "2023-04-20T12:00:00Z",
+        "total_reporting_units": 2,
+        "schema_version": "v1.0.0",
+        "sds_dataset_version": updated_dataset_version,
+        "filename": "test_filename.json",
+    },
+    {# without title
+        "survey_id": test_survey_id,
+        "period_id": test_period_id,
+        "form_types": ["oas", "alm", "lma"],
+        "sds_published_at": "2023-04-20T12:00:00Z",
+        "total_reporting_units": 2,
+        "schema_version": "v1.0.0",
+        "sds_dataset_version": first_dataset_version,
+        "filename": "test_filename.json",
+    },
+    { # with different period id
+        "survey_id": test_survey_id,
+        "period_id": f"{test_period_id}_2",
+        "form_types": ["knj", "okn", "ojdw"],
+        "title": "Which side was better?",
+        "sds_published_at": "2023-04-20T12:00:00Z",
+        "total_reporting_units": 2,
+        "schema_version": "v1.0.0",
+        "sds_dataset_version": first_dataset_version,
+        "filename": "test_filename.json",
+    }
+]
 
 # unit tests - dataset - test data
 dataset_metadata_collection: list[DatasetMetadata] = [
@@ -174,6 +226,26 @@ updated_dataset_metadata: DatasetMetadata = {
     **updated_dataset_metadata_without_id,
     "dataset_id": test_guid,
 }
+
+# integration test - dataset - test data
+dataset_unit_data_collection_endpoints: list[UnitDataset] = [
+    {
+        "dataset_id": "",
+        "survey_id": test_survey_id,
+        "period_id": test_period_id,
+        "schema_version": "v1.0.0",
+        "form_types": ["jke", "als", "sma"],
+        "data": "test",
+    },
+    {
+        "dataset_id": "",
+        "survey_id": test_survey_id,
+        "period_id": test_period_id,
+        "schema_version": "v1.0.0",
+        "form_types": ["skn", "qwd", "qkw"],
+        "data": "test"
+    },
+]
 
 # unit tests - dataset - test data
 unit_supplementary_data: UnitDataset = {

--- a/src/test_data/dataset_test_data.py
+++ b/src/test_data/dataset_test_data.py
@@ -91,8 +91,8 @@ dataset_metadata_updated_version: DatasetMetadata = {
     "filename": "test_filename.json",
 }
 
-# integration test - datasets - test data
-dataset_metadata_collection_endpoints: list[DatasetMetadata] = [
+# integration test - dataset endpoints - test data
+dataset_metadata_collection_for_endpoints_test: list[DatasetMetadata] = [
     {
         "dataset_id": "0",
         "survey_id": f"{test_survey_id}_1",
@@ -208,8 +208,8 @@ updated_dataset_metadata: DatasetMetadata = {
     "dataset_id": test_guid,
 }
 
-# integration test - dataset - test data
-dataset_unit_data_collection_endpoints: list[UnitDataset] = [
+# integration test - dataset endpoints - test data
+dataset_unit_data_collection_for_endpoints_test: list[UnitDataset] = [
     {
         "dataset_id": "",
         "survey_id": test_survey_id,

--- a/src/test_data/dataset_test_data.py
+++ b/src/test_data/dataset_test_data.py
@@ -94,7 +94,8 @@ dataset_metadata_updated_version: DatasetMetadata = {
 # integration test - datasets - test data
 dataset_metadata_collection_endpoints: list[DatasetMetadata] = [
     {
-        "survey_id": test_survey_id,
+        "dataset_id": "0",
+        "survey_id": f"{test_survey_id}_1",
         "period_id": test_period_id,
         "form_types": ["sda", "ajk", "iwu"],
         "title": "Which side was better?",
@@ -105,7 +106,8 @@ dataset_metadata_collection_endpoints: list[DatasetMetadata] = [
         "filename": "test_filename.json",
     },
     {
-        "survey_id": test_survey_id,
+         "dataset_id": "0",
+        "survey_id": f"{test_survey_id}_2",
         "period_id": test_period_id,
         "form_types": ["390", "219", "12O"],
         "title": "Which side was better?",
@@ -115,27 +117,6 @@ dataset_metadata_collection_endpoints: list[DatasetMetadata] = [
         "sds_dataset_version": updated_dataset_version,
         "filename": "test_filename.json",
     },
-    {# without title
-        "survey_id": test_survey_id,
-        "period_id": test_period_id,
-        "form_types": ["oas", "alm", "lma"],
-        "sds_published_at": "2023-04-20T12:00:00Z",
-        "total_reporting_units": 2,
-        "schema_version": "v1.0.0",
-        "sds_dataset_version": first_dataset_version,
-        "filename": "test_filename.json",
-    },
-    { # with different period id
-        "survey_id": test_survey_id,
-        "period_id": f"{test_period_id}_2",
-        "form_types": ["knj", "okn", "ojdw"],
-        "title": "Which side was better?",
-        "sds_published_at": "2023-04-20T12:00:00Z",
-        "total_reporting_units": 2,
-        "schema_version": "v1.0.0",
-        "sds_dataset_version": first_dataset_version,
-        "filename": "test_filename.json",
-    }
 ]
 
 # unit tests - dataset - test data

--- a/src/test_data/dataset_test_data.py
+++ b/src/test_data/dataset_test_data.py
@@ -106,7 +106,7 @@ dataset_metadata_collection_endpoints: list[DatasetMetadata] = [
         "filename": "test_filename.json",
     },
     {
-         "dataset_id": "1",
+        "dataset_id": "1",
         "survey_id": f"{test_survey_id}_2",
         "period_id": test_period_id,
         "form_types": ["390", "219", "12O"],


### PR DESCRIPTION
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Separates dataset integration test focusing on the happy path to simplify the test. 

### What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Split integration test for dataset endpoints (happy paths) into its own test class file (DatasetEndpointsIntegrationTest)
- Added tests for uploading and retrieving dataset metadata, fetching unit data, and handling datasets with missing titles.
- Introduced firestore helper function to upload datasets to firestore

### How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run the integration tests  check if datasets are uploaded with correct unit data and metadata.


### Links
<!--- Add any links to issues (jira, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://jira.ons.gov.uk/browse/SDSS-848

### Screenshots (if appropriate):