### PR TITLE
Sdss 849 dataset int test unhappy paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ integration-test-local:
 	export SURVEY_MAP_URL=${SURVEY_MAP_URL} && \
 	export FIRESTORE_DB_NAME="the-firestore-db-name" && \
 	export SDS_APPLICATION_VERSION=${SDS_APPLICATION_VERSION} && \
-	python -m pytest src/integration_tests -vv -W ignore::DeprecationWarning
+	python -m pytest --order-scope=module src/integration_tests -vv -W ignore::DeprecationWarning
 
 integration-test-sandbox:
 	export CONF=int-test && \
@@ -139,7 +139,7 @@ integration-test-sandbox:
 	export SURVEY_MAP_URL=${SURVEY_MAP_URL} && \
 	export FIRESTORE_DB_NAME=${PROJECT_ID}-sds && \
 	export SDS_APPLICATION_VERSION=${SDS_APPLICATION_VERSION} && \
-	python -m pytest src/integration_tests -vv -W ignore::DeprecationWarning
+	python -m pytest --order-scope=module src/integration_tests -vv -W ignore::DeprecationWarning
 
 #For use only by automated cloudbuild, is not intended to work locally.
 integration-test-cloudbuild:

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ integration-test-cloudbuild:
 	export SURVEY_MAP_URL=${INT_SURVEY_MAP_URL} && \
 	export FIRESTORE_DB_NAME=${INT_FIRESTORE_DB_NAME} && \
 	export SDS_APPLICATION_VERSION=${SDS_APPLICATION_VERSION} && \
-	python -m pytest src/integration_tests -vv -W ignore::DeprecationWarning
+	python -m pytest --order-scope=module src/integration_tests -vv -W ignore::DeprecationWarning
 
 generate-spec:
 	export CONF=cloud-dev && \

--- a/src/integration_tests/datasets/dataset_cloud_function_integration_test.py
+++ b/src/integration_tests/datasets/dataset_cloud_function_integration_test.py
@@ -26,8 +26,7 @@ from src.test_data.shared_test_data import (
     test_dataset_subscriber_id,
 )
 
-
-class E2EDatasetIntegrationTest(TestCase):
+class DatasetCloudFunctionIntegrationTest(TestCase):
     @classmethod
     def setup_class(self) -> None:
         cleanup()

--- a/src/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/src/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -4,7 +4,8 @@ from src.app.config.config_factory import config
 from src.test_data.dataset_test_data import ( 
     dataset_metadata_collection_for_endpoints_test, 
     dataset_unit_data_collection_for_endpoints_test,
-    dataset_unit_data_id
+    dataset_unit_data_id,
+    dataset_metadata_404,
 )
 from repositories.firebase.firebase_loader import firebase_loader
 from src.integration_tests.helpers.integration_helpers import (
@@ -169,7 +170,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
             
         response = self.session.get(
             f"{config.API_URL}/v1/dataset_metadata?"
-            f"survey_id=xyz&period_id=abc",
+            f"survey_id={dataset_metadata_404['survey_id']}&period_id={dataset_metadata_404['period_id']}",
             headers = self.headers
         )
 
@@ -247,7 +248,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
             
         response = self.session.get(
             f"{config.API_URL}/v1/unit_data?"
-            f"dataset_id=xyz&identifier=abc",
+            f"dataset_id={dataset_metadata_404['dataset_id']}&identifier={dataset_metadata_404['identifier']}",
             headers = self.headers
         )
 

--- a/src/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/src/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -6,6 +6,7 @@ from src.test_data.dataset_test_data import (
     dataset_unit_data_collection_for_endpoints_test,
     dataset_unit_data_id,
     dataset_404_test_data,
+    random_string,
 )
 from repositories.firebase.firebase_loader import firebase_loader
 from src.integration_tests.helpers.integration_helpers import (
@@ -119,7 +120,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
     
 
     @pytest.mark.order(4)
-    def test_dataset_without_survey_id(self):
+    def test_dataset_metadata_without_survey_id(self):
         """
         Test for /v1/dataset_metadata endpoint without passing survey_id parameter
         
@@ -139,7 +140,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
 
 
     @pytest.mark.order(5)
-    def test_dataset_without_period_id(self):
+    def test_dataset_metadata_without_period_id(self):
         """
         Test for /v1/dataset_metadata endpoint without passing period_id parameter
         
@@ -157,8 +158,45 @@ class DatasetEndpointsIntegrationTest(TestCase):
         assert response.status_code == 400
         assert response.json()["message"] == "Invalid search parameters provided"
 
-
     @pytest.mark.order(6)
+    def test_dataset_metadata_no_valid_query_params(self):
+        """
+        Test for /v1/dataset_metadata endpoint without passing valid query parameters
+        
+        - Get request to retrieve metadata without passing valid query parameters
+        - Assert status code is 400
+        - Checks the error message in the response
+        """
+            
+        response = self.session.get(
+            f"{config.API_URL}/v1/dataset_metadata",
+            headers = self.headers
+        )
+
+        assert response.status_code == 400
+        assert response.json()["message"] == "Invalid search parameters provided"
+    
+    @pytest.mark.order(7)
+    def test_dataset_metadata_garbage_query_params(self):
+        """
+        Test for /v1/dataset_metadata endpoint with garbage query parameters
+        
+        - Get request to retrieve metadata with garbage query parameters
+        - Assert status code is 400
+        - Checks the error message in the response
+        """
+            
+        response = self.session.get(
+            f"{config.API_URL}/v1/dataset_metadata?"
+            f"{random_string}",
+            headers = self.headers
+        )
+
+        assert response.status_code == 400
+        assert response.json()["message"] == "Invalid search parameters provided"
+
+
+    @pytest.mark.order(8)
     def test_dataset_metadata_404_response(self):
         """
         Test for /v1/dataset_metadata endpoint when no dataset metadata is retrieved
@@ -177,7 +215,8 @@ class DatasetEndpointsIntegrationTest(TestCase):
         assert response.status_code == 404
         assert response.json()["message"] == "No datasets found"
 
-    @pytest.mark.order(7)
+
+    @pytest.mark.order(9)
     def test_dataset_metadata_unauthorised(self):
         """
         Test the /v1/dataset_metadata endpoint with an unauthorized token
@@ -196,7 +235,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
         assert response.status_code == 401
 
 
-    @pytest.mark.order(8)
+    @pytest.mark.order(10)
     def test_dataset_unit_data_without_dataset_id(self):
         """
         Test for /v1/unit_data endpoint without passing dataset_id parameter
@@ -216,7 +255,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
         assert response.json()["message"] == "Validation has failed"
 
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(11)
     def test_dataset_unit_data_without_identifier(self):
         """
         Test for /v1/unit_data endpoint without passing identifier parameter
@@ -236,7 +275,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
         assert response.json()["message"] == "Validation has failed"
     
 
-    @pytest.mark.order(10)
+    @pytest.mark.order(12)
     def test_dataset_unit_data_404_response(self):
         """
         Test for /v1/unit_data endpoint when no unit data is retrieved
@@ -255,7 +294,8 @@ class DatasetEndpointsIntegrationTest(TestCase):
         assert response.status_code == 404
         assert response.json()["message"] == "No unit data found"
 
-    @pytest.mark.order(11)
+
+    @pytest.mark.order(13)
     def test_dataset_unit_data_unauthorised(self):
         """
         Test the /v1/unit_data endpoint with an unauthorized token
@@ -272,4 +312,43 @@ class DatasetEndpointsIntegrationTest(TestCase):
         )
 
         assert response.status_code == 401
+
+
+    @pytest.mark.order(14)
+    def test_dataset_unit_data_no_valid_query_params(self):
+        """
+        Test for /v1/unit_data endpoint without passing valid query parameters
+        
+        - Get request to retrieve unit data without passing valid query parameters
+        - Assert status code is 400
+        - Checks the error message in the response
+        """
+            
+        response = self.session.get(
+            f"{config.API_URL}/v1/unit_data",
+            headers = self.headers
+        )
+
+        assert response.status_code == 400
+        assert response.json()["message"] == "Validation has failed"
+
+    
+    @pytest.mark.order(15)
+    def test_dataset_unit_data_garbage_query_params(self):
+        """
+        Test for /v1/unit_data endpoint with garbage query parameters
+        
+        - Get request to retrieve unit data with garbage query parameters
+        - Assert status code is 400
+        - Checks the error message in the response
+        """
+            
+        response = self.session.get(
+            f"{config.API_URL}/v1/unit_data?"
+            f"{random_string}",
+            headers = self.headers
+        )
+
+        assert response.status_code == 400
+        assert response.json()["message"] == "Validation has failed"
         

--- a/src/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/src/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -13,7 +13,6 @@ from src.integration_tests.helpers.integration_helpers import (
     cleanup,
     generate_headers,
     setup_session,
-    inject_wait_time,
 )
 from src.integration_tests.helpers.firestore_helpers import upload_dataset
 from google.cloud import firestore
@@ -35,7 +34,6 @@ class DatasetEndpointsIntegrationTest(TestCase):
     @classmethod
     def setup_class(self) -> None:
         cleanup()
-        inject_wait_time(3) # Inject wait time to allow resources properly set up
         self.session = setup_session()
         self.headers = generate_headers()
         self.firestore_client = firestore.Client(project=config.PROJECT_ID, database=config.FIRESTORE_DB_NAME)

--- a/src/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/src/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -16,11 +16,12 @@ from src.integration_tests.helpers.integration_helpers import (
 from src.integration_tests.helpers.firestore_helpers import upload_dataset
 from google.cloud import firestore
 
+
 class DatasetEndpointsIntegrationTest(TestCase):
     """
     Integration tests for the Dataset Endpoints.
 
-    This test covers fetching metdata and unit data from firestore,
+    This test covers fetching metadata and unit data from firestore,
     and checking that dataset metadata and unit data is handled correctly.
     """
     session = None
@@ -44,7 +45,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
     @pytest.mark.order(1)
     def test_get_dataset_metadata_collection(self):
         """
-        Test retriving dataset metadata.
+        Test the GET /v1/dataset_metadata endpoint by retrieving dataset metadata.
 
         - Sends a GET request to retrieve metadata for a dataset
         - Asserts the metadata retrieved matches the expected structure.
@@ -71,7 +72,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
     @pytest.mark.order(2)
     def test_get_dataset_unit_supplementary_data(self):
         """
-        Test retrieving unit data for a dataset
+        Test the /v1/unit_data endpoint by retrieving unit data for a dataset
 
         - Get request to retrieve unit data for a dataset
         - Asserts if unit data matches the expected structure
@@ -86,10 +87,11 @@ class DatasetEndpointsIntegrationTest(TestCase):
         assert response.status_code == 200
         assert response.json() == dataset_unit_data_collection_for_endpoints_test[0]
 
+
     @pytest.mark.order(3)
     def test_dataset_without_title(self):
         """
-        Test retrieving a dataset metadata without a title
+        Test the /v1/dataset_metadata endpoint retrieving a dataset metadata without a title
 
         - Get request to retrieve a metadata missing a title
         - Assert status code is 200
@@ -111,4 +113,124 @@ class DatasetEndpointsIntegrationTest(TestCase):
 
         assert response.status_code == 200
         assert response.json() == expected_data
+    
+
+    @pytest.mark.order(4)
+    def test_dataset_without_survey_id(self):
+        """
+        Test for /v1/dataset_metadata endpoint without passing survey_id parameter
+        
+        - Get request to retrieve metadata without passing survey_id
+        - Assert status code is 400
+        - Checks the error message in the response
+        """
+            
+        response = self.session.get(
+            f"{config.API_URL}/v1/dataset_metadata?"
+            f"period_id={dataset_metadata_collection_for_endpoints_test[0]['period_id']}",
+            headers = self.headers
+        )
+
+        assert response.status_code == 400
+        assert response.json()["message"] == "Invalid search parameters provided"
+
+
+    @pytest.mark.order(5)
+    def test_dataset_without_period_id(self):
+        """
+        Test for /v1/dataset_metadata endpoint without passing period_id parameter
+        
+        - Get request to retrieve metadata without passing period_id
+        - Assert status code is 400
+        - Checks the error message in the response
+        """
+            
+        response = self.session.get(
+            f"{config.API_URL}/v1/dataset_metadata?"
+            f"survey_id={dataset_metadata_collection_for_endpoints_test[0]['survey_id']}",
+            headers = self.headers
+        )
+
+        assert response.status_code == 400
+        assert response.json()["message"] == "Invalid search parameters provided"
+
+
+    @pytest.mark.order(6)
+    def test_dataset_metadata_404_response(self):
+        """
+        Test for /v1/dataset_metadata endpoint when no dataset metadata is retrieved
+        
+        - Get request to retrieve metadata when no dataset is found
+        - Assert status code is 404
+        - Checks the error message in the response
+        """
+            
+        response = self.session.get(
+            f"{config.API_URL}/v1/dataset_metadata?"
+            f"survey_id=xyz&period_id=abc",
+            headers = self.headers
+        )
+
+        assert response.status_code == 404
+        assert response.json()["message"] == "No datasets found"
+
+
+    @pytest.mark.order(7)
+    def test_dataset_unit_data_without_dataset_id(self):
+        """
+        Test for /v1/unit_data endpoint without passing dataset_id parameter
+        
+        - Get request to retrieve unit data without passing dataset_id
+        - Assert status code is 400
+        - Checks the error message in the response
+        """
+            
+        response = self.session.get(
+            f"{config.API_URL}/v1/unit_data?"
+            f"identifier={dataset_unit_data_id[0]}",
+            headers = self.headers
+        )
+
+        assert response.status_code == 400
+        assert response.json()["message"] == "Validation has failed"
+
+
+    @pytest.mark.order(8)
+    def test_dataset_unit_data_without_identifier(self):
+        """
+        Test for /v1/unit_data endpoint without passing identifier parameter
+        
+        - Get request to retrieve unit data without passing identifier
+        - Assert status code is 400
+        - Checks the error message in the response
+        """
+            
+        response = self.session.get(
+            f"{config.API_URL}/v1/unit_data?"
+            f"dataset_id={dataset_unit_data_collection_for_endpoints_test[0]['dataset_id']}",
+            headers = self.headers
+        )
+
+        assert response.status_code == 400
+        assert response.json()["message"] == "Validation has failed"
+    
+
+    @pytest.mark.order(9)
+    def test_dataset_unit_data_404_response(self):
+        """
+        Test for /v1/unit_data endpoint when no unit data is retrieved
+        
+        - Get request to retrieve unit data when no unit data is found
+        - Assert status code is 404
+        - Checks the error message in the response
+        """
+            
+        response = self.session.get(
+            f"{config.API_URL}/v1/unit_data?"
+            f"dataset_id=xyz&identifier=abc",
+            headers = self.headers
+        )
+
+        assert response.status_code == 404
+        assert response.json()["message"] == "No unit data found"
         

--- a/src/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/src/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -5,7 +5,7 @@ from src.test_data.dataset_test_data import (
     dataset_metadata_collection_for_endpoints_test, 
     dataset_unit_data_collection_for_endpoints_test,
     dataset_unit_data_id,
-    dataset_metadata_404,
+    dataset_404_test_data,
 )
 from repositories.firebase.firebase_loader import firebase_loader
 from src.integration_tests.helpers.integration_helpers import (
@@ -170,7 +170,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
             
         response = self.session.get(
             f"{config.API_URL}/v1/dataset_metadata?"
-            f"survey_id={dataset_metadata_404['survey_id']}&period_id={dataset_metadata_404['period_id']}",
+            f"survey_id={dataset_404_test_data['survey_id']}&period_id={dataset_404_test_data['period_id']}",
             headers = self.headers
         )
 
@@ -248,7 +248,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
             
         response = self.session.get(
             f"{config.API_URL}/v1/unit_data?"
-            f"dataset_id={dataset_metadata_404['dataset_id']}&identifier={dataset_metadata_404['identifier']}",
+            f"dataset_id={dataset_404_test_data['dataset_id']}&identifier={dataset_404_test_data['identifier']}",
             headers = self.headers
         )
 

--- a/src/integration_tests/status/status_router_integration_test.py
+++ b/src/integration_tests/status/status_router_integration_test.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from fastapi import status
+import pytest
 
 from src.app.config.config_factory import config
 from src.integration_tests.helpers.integration_helpers import (
@@ -10,9 +11,15 @@ from src.integration_tests.helpers.integration_helpers import (
 
 
 class TestHttpGetDeploymentStatus(TestCase):
+    
+    @pytest.mark.order(1)
     def test_endpoint_returns_right_response_if_deployment_successful(self):
         """
         Endpoint should return `HTTP_200_OK` and the right response if the deployment is successful
+
+        - Sends a GET request to the /status endpoint
+        - Asserts the response status code is 200
+        - Asserts the response body contains the right version and status
         """
         session = setup_session()
         headers = generate_headers()
@@ -26,9 +33,14 @@ class TestHttpGetDeploymentStatus(TestCase):
         assert response_as_json["version"] == config.SDS_APPLICATION_VERSION
         assert response_as_json["status"] == "OK"
 
+
+    @pytest.mark.order(2)
     def test_endpoint_returns_unauthorized_request(self):
         """
         Endpoint should return a 401 unauthorized error if the endpoint is requested with an unauthorized token.
+
+        - Sends a GET request to the /status endpoint with an unauthorized token
+        - Asserts the response status code is 401
         """
         if config.OAUTH_CLIENT_ID.__contains__("local"):
             pass

--- a/src/test_data/dataset_test_data.py
+++ b/src/test_data/dataset_test_data.py
@@ -380,6 +380,14 @@ unit_response_amended = {
     "data": "<encrypted data>",
 }
 
+# e2e dataset integration test - test data for testing 404 response of dataset endpoints
+dataset_metadata_404 = {
+    "survey_id": "111",
+    "period_id": "222",
+    "dataset_id": "333",
+    "identifier": "444",
+}
+
 # unused
 incorrect_file_extension_message = {
     "error": "Filetype error",

--- a/src/test_data/dataset_test_data.py
+++ b/src/test_data/dataset_test_data.py
@@ -381,7 +381,7 @@ unit_response_amended = {
 }
 
 # e2e dataset integration test - test data for testing 404 response of dataset endpoints
-dataset_metadata_404 = {
+dataset_404_test_data = {
     "survey_id": "111",
     "period_id": "222",
     "dataset_id": "333",

--- a/src/test_data/dataset_test_data.py
+++ b/src/test_data/dataset_test_data.py
@@ -388,6 +388,9 @@ dataset_404_test_data = {
     "identifier": "444",
 }
 
+# e2e dataset integration test - random string to test invalid query params
+random_string = "random_string"
+
 # unused
 incorrect_file_extension_message = {
     "error": "Filetype error",


### PR DESCRIPTION
### Motivation and Context
There are insufficient integration tests for unhappy paths for the dataset endpoints in SDS. This work is to remedy that. 

### What has changed
- Add new tests for unhappy paths for dataset endpoints
- Fix ordering issue by adding `--order-scope=module` option to Makefile integration test command (see docs link below).
- Rename status endpoint directory for clarity and add ordering to the test class
- Rename dataset Cloud Function test class for clarity

### How to test?
- Run integration tests

### Links
- [Jira ticket](https://jira.ons.gov.uk/browse/SDSS-849)
- [pytest-monitoring documentation ](https://pytest-order.readthedocs.io/en/stable/configuration.html#)
