### PR TITLE
Dfts 1540 oauth api shutdown

### DIFF
--- a/app/routers/schema_router.py
+++ b/app/routers/schema_router.py
@@ -269,6 +269,7 @@ async def get_survey_id_map(
         raise exceptions.ExceptionNoSurveyIDs
     return survey_id_map
 
+
 @router.get(
     "/v1/all_schema_metadata",
     response_model=list[SchemaMetadata],

--- a/cloudbuild-dev.yaml
+++ b/cloudbuild-dev.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: docker
+  - name: gcr.io/cloud-builders/docker
     id: "docker build and push"
     entrypoint: sh
     args:
@@ -48,6 +48,7 @@ steps:
         "run",
         "deploy",
         "sds",
+        "--no-invoker-iam-check",
         "--image",
         "europe-west2-docker.pkg.dev/${PROJECT_ID}/sds/sds:${SHORT_SHA}",
         "--region",

--- a/cloudbuild-dev.yaml
+++ b/cloudbuild-dev.yaml
@@ -48,6 +48,7 @@ steps:
         "run",
         "deploy",
         "sds",
+        "--no-invoker-iam-check",
         "--image",
         "europe-west2-docker.pkg.dev/${PROJECT_ID}/sds/sds:${SHORT_SHA}",
         "--region",
@@ -67,25 +68,6 @@ steps:
         "1",
       ]
 
-  - name: "gcr.io/cloud-builders/gcloud"
-    id: "Retrieve `OAUTH_BRAND_NAME` and save it to workspace"
-    entrypoint: sh
-    args:
-      - "-c"
-      - |
-        gcloud iap oauth-brands list --format='value(name)' --limit=1 --project=${PROJECT_ID} \
-        > /workspace/oauth_brand_name
-
-  - name: "gcr.io/cloud-builders/gcloud"
-    id: "Retrieve `OAUTH_CLIENT_NAME` and save it to workspace"
-    entrypoint: sh
-    args:
-      - "-c"
-      - |
-        gcloud iap oauth-clients list $(cat /workspace/oauth_brand_name) --format='value(name)' \
-        --limit=1 \
-        > /workspace/oauth_client_name
-
   - name: python:3.13
     id: "Run integration test"
     entrypoint: sh
@@ -97,10 +79,9 @@ steps:
         export INT_SCHEMA_BUCKET_NAME=${_SCHEMA_BUCKET_NAME}
         export INT_PUBLISH_SCHEMA_TOPIC_ID=${_PUBLISH_SCHEMA_TOPIC_ID}
         export INT_API_URL=${_API_URL}
-        OAUTH_CLIENT_NAME=$(cat /workspace/oauth_client_name)
-        export INT_OAUTH_CLIENT_ID=${OAUTH_CLIENT_NAME##*/}
         export INT_SURVEY_MAP_URL=${_SURVEY_MAP_URL}
         export INT_FIRESTORE_DB_NAME=${_FIRESTORE_DB_NAME}
+        export SECRET_ID=iap-secret
         pip install --upgrade pip --user
         pip install uv
         uv sync

--- a/cloudbuild-dev.yaml
+++ b/cloudbuild-dev.yaml
@@ -48,7 +48,6 @@ steps:
         "run",
         "deploy",
         "sds",
-        "--no-invoker-iam-check",
         "--image",
         "europe-west2-docker.pkg.dev/${PROJECT_ID}/sds/sds:${SHORT_SHA}",
         "--region",

--- a/cloudbuild-prod.yaml
+++ b/cloudbuild-prod.yaml
@@ -25,6 +25,7 @@ steps:
         "run",
         "deploy",
         "sds",
+        "--no-invoker-iam-check",
         "--image",
         "europe-west2-docker.pkg.dev/ons-sds-ci/sds-perm/${PROJECT_ID}:latest",
         "--region",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,15 +18,20 @@ dependencies = [
     "pytest-order==1.3.0",
     "functions-framework==3.9.2",
     "google-cloud-firestore==2.21.0",
-    "google-cloud-storage==3.4.0",
-    "google-cloud-pubsub==2.31.1",
+    "google-cloud-storage==3.9.0",
+    "google-cloud-pubsub==2.33.0",
     "google-cloud-scheduler==2.16.1",
     "pip_audit==2.9.0",
     "pyyaml==6.0.3",
     "ruff==0.13.2",
     "setuptools==80.9.0",
     "tomlkit==0.13.3",
+    "sds-common==1.0.10",
 ]
+
+[[tool.uv.index]]
+name = "sds-repo"
+url = "https://europe-west2-python.pkg.dev/ons-sds-ci/sds-python-packages/simple/"
 
 [dependency-groups]
 version-check = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sds"
-version = "2.2.3"
+version = "2.2.4"
 description = "Supplementary Data Service"
 requires-python = ">=3.13,<3.14"
 dependencies = [

--- a/tests/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/tests/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -10,11 +10,11 @@ from tests.test_data.dataset_test_data import (
 )
 from tests.integration_tests.helpers.integration_helpers import (
     cleanup,
-    generate_headers,
     setup_session,
 )
 from tests.integration_tests.helpers.firestore_helpers import upload_dataset
 from google.cloud import firestore
+from sds_common.services.http_service import HttpService
 
 
 class DatasetEndpointsIntegrationTest(TestCase):
@@ -34,7 +34,7 @@ class DatasetEndpointsIntegrationTest(TestCase):
     def setup_class(self) -> None:
         cleanup()
         self.session = setup_session()
-        self.headers = generate_headers()
+        self.headers = HttpService.generate_authentication_headers()
         self.firestore_client = firestore.Client(project=config.PROJECT_ID, database=config.FIRESTORE_DB_NAME)
         self.dataset = upload_dataset(self.firestore_client, dataset_metadata_collection_for_endpoints_test, dataset_unit_data_collection_for_endpoints_test)
         self.invalid_token_headers = {"Authorization": "Bearer invalid_token"}

--- a/tests/integration_tests/helpers/integration_helpers.py
+++ b/tests/integration_tests/helpers/integration_helpers.py
@@ -1,7 +1,6 @@
 import json
 import time
 
-import google.oauth2.id_token
 import requests
 from app.config.config_factory import config
 from app.repositories.buckets.bucket_loader import bucket_loader
@@ -41,31 +40,6 @@ def setup_session() -> requests.Session:
     session.mount("https://", adapter)
 
     return session
-
-
-def generate_headers() -> dict[str, str]:
-    """
-    Method to create headers for authentication if connecting to a remote version of the API.
-
-    Parameters:
-        None
-
-    Returns:
-        dict[str, str]: the headers required for remote authentication.
-    """
-    headers = {}
-
-    auth_req = google.auth.transport.requests.Request()
-    auth_token = google.oauth2.id_token.fetch_id_token(
-        auth_req, audience=config.OAUTH_CLIENT_ID
-    )
-
-    headers = {
-        "Authorization": f"Bearer {auth_token}",
-        "Content-Type": "application/json",
-    }
-
-    return headers
 
 
 def load_json(filepath: str) -> dict:

--- a/tests/integration_tests/schemas/schema_endpoints_integrations_test.py
+++ b/tests/integration_tests/schemas/schema_endpoints_integrations_test.py
@@ -3,7 +3,6 @@ import pytest
 from app.config.config_factory import config
 from tests.integration_tests.helpers.integration_helpers import (
     cleanup,
-    generate_headers,
     load_json,
     pubsub_setup,
     pubsub_teardown,
@@ -16,6 +15,8 @@ from tests.integration_tests.helpers.pubsub_helper import schema_pubsub_helper
 from tests.test_data.schema_test_data import test_survey_id_map
 from tests.test_data.shared_test_data import test_schema_subscriber_id, test_survey_id_list
 from tests.test_data.schema_test_data import invalid_survey_id, invalid_data, test_survey_id
+from sds_common.services.http_service import HttpService
+
 
 class SchemaEndpointsIntegrationTest(TestCase):
     session = None
@@ -31,7 +32,7 @@ class SchemaEndpointsIntegrationTest(TestCase):
         inject_wait_time(3) # Inject wait time to allow resources properly set up
         # initialise class attributes
         self.session = setup_session()
-        self.headers = generate_headers()
+        self.headers = HttpService.generate_authentication_headers()
         self.test_schemas = []
         # We add the 2nd version of the schema first to ease the testing of the schema as metadata endpoint lists newest schema versions first
         self.test_schemas.append(load_json(f"{config.TEST_SCHEMA_PATH}schema_2.json"))

--- a/tests/integration_tests/status/status_router_integration_test.py
+++ b/tests/integration_tests/status/status_router_integration_test.py
@@ -5,9 +5,9 @@ import pytest
 
 from app.config.config_factory import config
 from tests.integration_tests.helpers.integration_helpers import (
-    generate_headers,
     setup_session,
 )
+from sds_common.services.http_service import HttpService
 
 
 class TestHttpGetDeploymentStatus(TestCase):
@@ -22,7 +22,7 @@ class TestHttpGetDeploymentStatus(TestCase):
         - Asserts the response body contains the right version and status
         """
         session = setup_session()
-        headers = generate_headers()
+        headers = HttpService.generate_authentication_headers()
 
         status_response = session.get(
             f"{config.API_URL}/status",

--- a/uv.lock
+++ b/uv.lock
@@ -71,11 +71,11 @@ filecache = [
 
 [[package]]
 name = "cachetools"
-version = "6.2.0"
+version = "5.5.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/61/e4fad8155db4a04bfb4734c7c8ff0882f078f24294d42798b3568eb63bff/cachetools-6.2.0.tar.gz", hash = "sha256:38b328c0889450f05f5e120f56ab68c8abaf424e1275522b138ffc93253f7e32", size = 30988, upload-time = "2025-08-25T18:57:30.924Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380, upload-time = "2025-02-20T21:01:19.524Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/56/3124f61d37a7a4e7cc96afc5492c78ba0cb551151e530b54669ddd1436ef/cachetools-6.2.0-py3-none-any.whl", hash = "sha256:1c76a8960c0041fcc21097e357f882197c79da0dbff766e7317890a65d7d8ba6", size = 11276, upload-time = "2025-08-25T18:57:29.684Z" },
+    { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080, upload-time = "2025-02-20T21:01:16.647Z" },
 ]
 
 [[package]]
@@ -354,7 +354,7 @@ wheels = [
 
 [[package]]
 name = "google-api-core"
-version = "2.25.1"
+version = "2.30.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth" },
@@ -363,9 +363,9 @@ dependencies = [
     { name = "protobuf" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/21/e9d043e88222317afdbdb567165fdbc3b0aad90064c7e0c9eb0ad9955ad8/google_api_core-2.25.1.tar.gz", hash = "sha256:d2aaa0b13c78c61cb3f4282c464c046e45fbd75755683c9c525e6e8f7ed0a5e8", size = 165443, upload-time = "2025-06-12T20:52:20.439Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/98/586ec94553b569080caef635f98a3723db36a38eac0e3d7eb3ea9d2e4b9a/google_api_core-2.30.0.tar.gz", hash = "sha256:02edfa9fab31e17fc0befb5f161b3bf93c9096d99aed584625f38065c511ad9b", size = 176959, upload-time = "2026-02-18T20:28:11.926Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/4b/ead00905132820b623732b175d66354e9d3e69fcf2a5dcdab780664e7896/google_api_core-2.25.1-py3-none-any.whl", hash = "sha256:8a2a56c1fef82987a524371f99f3bd0143702fecc670c72e600c1cda6bf8dbb7", size = 160807, upload-time = "2025-06-12T20:52:19.334Z" },
+    { url = "https://files.pythonhosted.org/packages/45/27/09c33d67f7e0dcf06d7ac17d196594e66989299374bfb0d4331d1038e76b/google_api_core-2.30.0-py3-none-any.whl", hash = "sha256:80be49ee937ff9aba0fd79a6eddfde35fe658b9953ab9b79c57dd7061afa8df5", size = 173288, upload-time = "2026-02-18T20:28:10.367Z" },
 ]
 
 [package.optional-dependencies]
@@ -376,16 +376,16 @@ grpc = [
 
 [[package]]
 name = "google-auth"
-version = "2.41.1"
+version = "2.38.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
     { name = "pyasn1-modules" },
     { name = "rsa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/af/5129ce5b2f9688d2fa49b463e544972a7c82b0fdb50980dafee92e121d9f/google_auth-2.41.1.tar.gz", hash = "sha256:b76b7b1f9e61f0cb7e88870d14f6a94aeef248959ef6992670efee37709cbfd2", size = 292284, upload-time = "2025-09-30T22:51:26.363Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/eb/d504ba1daf190af6b204a9d4714d457462b486043744901a6eeea711f913/google_auth-2.38.0.tar.gz", hash = "sha256:8285113607d3b80a3f1543b75962447ba8a09fe85783432a784fdeef6ac094c4", size = 270866, upload-time = "2025-01-23T01:05:29.119Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/a4/7319a2a8add4cc352be9e3efeff5e2aacee917c85ca2fa1647e29089983c/google_auth-2.41.1-py2.py3-none-any.whl", hash = "sha256:754843be95575b9a19c604a848a41be03f7f2afd8c019f716dc1f51ee41c639d", size = 221302, upload-time = "2025-09-30T22:51:24.212Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/47/603554949a37bca5b7f894d51896a9c534b9eab808e2520a748e081669d0/google_auth-2.38.0-py2.py3-none-any.whl", hash = "sha256:e7dae6694313f434a2727bf2906f27ad259bae090d7aa896590d86feec3d9d4a", size = 210770, upload-time = "2025-01-23T01:05:26.572Z" },
 ]
 
 [[package]]
@@ -419,7 +419,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-pubsub"
-version = "2.31.1"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
@@ -432,9 +432,9 @@ dependencies = [
     { name = "proto-plus" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/5a/6142bc0754cb6f3ed330d58a28e07810539dcab23662be932a532e3f249b/google_cloud_pubsub-2.31.1.tar.gz", hash = "sha256:f4214f692da435afcdfb41e77cfa962238db96e4a4ba64637aaa710442d9c532", size = 391409, upload-time = "2025-07-28T21:18:37.244Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/dd/6e016dc4c893b8a7eee9f5a4ca8659a886164580bfb129b744f47aff1cde/google_cloud_pubsub-2.33.0.tar.gz", hash = "sha256:83bc50c54f669efb924ad21385bc7092fa11f7576eabef3d0b4d7aa8efa90aa6", size = 393962, upload-time = "2025-10-30T20:13:08.226Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/96/b96c03726126c71b5b7526176feb3114db3323550ab5d1b6d43673378bbc/google_cloud_pubsub-2.31.1-py3-none-any.whl", hash = "sha256:85e9ee330874d725dacf20d65efd52e5ec04141ca04f023d135b961a68b372b0", size = 319167, upload-time = "2025-07-28T21:18:35.412Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/35/6f341d8b2e94cb61b6ead415e582e3fd697472ccef9bc3972c6d83e6273f/google_cloud_pubsub-2.33.0-py3-none-any.whl", hash = "sha256:d7af3b6448c9adc171f677a989dafb4c67df6112140bd4633f4bf7e3ebe67aa0", size = 321254, upload-time = "2025-10-30T20:13:06.37Z" },
 ]
 
 [[package]]
@@ -453,8 +453,25 @@ wheels = [
 ]
 
 [[package]]
+name = "google-cloud-secret-manager"
+version = "2.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpc-google-iam-v1" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/9c/a6c7144bc96df77376ae3fcc916fb639c40814c2e4bba2051d31dc136cd0/google_cloud_secret_manager-2.26.0.tar.gz", hash = "sha256:0d1d6f76327685a0ed78a4cf50f289e1bfbbe56026ed0affa98663b86d6d50d6", size = 277603, upload-time = "2025-12-18T00:29:31.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/30/a58739dd12cec0f7f761ed1efb518aed2250a407d4ed14c5a0eeee7eaaf9/google_cloud_secret_manager-2.26.0-py3-none-any.whl", hash = "sha256:940a5447a6ec9951446fd1a0f22c81a4303fde164cd747aae152c5f5c8e6723e", size = 223623, upload-time = "2025-12-18T00:29:29.311Z" },
+]
+
+[[package]]
 name = "google-cloud-storage"
-version = "3.4.0"
+version = "3.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core" },
@@ -464,9 +481,9 @@ dependencies = [
     { name = "google-resumable-media" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/a6/6e0a318f70975a3c048c0e1a18aee4f7b6d7dac1e798fdc5353c5248d418/google_cloud_storage-3.4.0.tar.gz", hash = "sha256:4c77ec00c98ccc6428e4c39404926f41e2152f48809b02af29d5116645c3c317", size = 17226847, upload-time = "2025-09-15T10:40:05.045Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/b1/4f0798e88285b50dfc60ed3a7de071def538b358db2da468c2e0deecbb40/google_cloud_storage-3.9.0.tar.gz", hash = "sha256:f2d8ca7db2f652be757e92573b2196e10fbc09649b5c016f8b422ad593c641cc", size = 17298544, upload-time = "2026-02-02T13:36:34.119Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/12/164a90e4692423ed5532274928b0e19c8cae345ae1aa413d78c6b688231b/google_cloud_storage-3.4.0-py3-none-any.whl", hash = "sha256:16eeca305e4747a6871f8f7627eef3b862fdd365b872ca74d4a89e9841d0f8e8", size = 278423, upload-time = "2025-09-15T10:40:03.349Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0b/816a6ae3c9fd096937d2e5f9670558908811d57d59ddf69dd4b83b326fd1/google_cloud_storage-3.9.0-py3-none-any.whl", hash = "sha256:2dce75a9e8b3387078cbbdad44757d410ecdb916101f8ba308abf202b6968066", size = 321324, upload-time = "2026-02-02T13:36:32.271Z" },
 ]
 
 [[package]]
@@ -1177,7 +1194,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.32.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1185,9 +1202,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218, upload-time = "2024-05-29T15:37:49.536Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928, upload-time = "2024-05-29T15:37:47.027Z" },
 ]
 
 [[package]]
@@ -1302,6 +1319,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "ruff" },
+    { name = "sds-common" },
     { name = "setuptools" },
     { name = "tomlkit" },
     { name = "uvicorn" },
@@ -1320,9 +1338,9 @@ requires-dist = [
     { name = "firebase-admin", specifier = "==7.1.0" },
     { name = "functions-framework", specifier = "==3.9.2" },
     { name = "google-cloud-firestore", specifier = "==2.21.0" },
-    { name = "google-cloud-pubsub", specifier = "==2.31.1" },
+    { name = "google-cloud-pubsub", specifier = "==2.33.0" },
     { name = "google-cloud-scheduler", specifier = "==2.16.1" },
-    { name = "google-cloud-storage", specifier = "==3.4.0" },
+    { name = "google-cloud-storage", specifier = "==3.9.0" },
     { name = "gunicorn", specifier = "==23.0.0" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "jsonschema", specifier = "==4.25.1" },
@@ -1334,6 +1352,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = "==1.1.1" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "ruff", specifier = "==0.13.2" },
+    { name = "sds-common", specifier = "==1.0.10" },
     { name = "setuptools", specifier = "==80.9.0" },
     { name = "tomlkit", specifier = "==0.13.3" },
     { name = "uvicorn", specifier = "===0.37.0" },
@@ -1343,6 +1362,31 @@ requires-dist = [
 version-check = [
     { name = "toml", specifier = ">=0.10.2" },
     { name = "tomlkit", specifier = ">=0.13.3" },
+]
+
+[[package]]
+name = "sds-common"
+version = "1.0.10"
+source = { registry = "https://europe-west2-python.pkg.dev/ons-sds-ci/sds-python-packages/simple/" }
+dependencies = [
+    { name = "cloudevents" },
+    { name = "firebase-admin" },
+    { name = "functions-framework" },
+    { name = "google-auth" },
+    { name = "google-cloud-firestore" },
+    { name = "google-cloud-pubsub" },
+    { name = "google-cloud-secret-manager" },
+    { name = "google-cloud-storage" },
+    { name = "pip-audit" },
+    { name = "pydantic-settings" },
+    { name = "pytest-order" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://europe-west2-python.pkg.dev/ons-sds-ci/sds-python-packages/sds-common/sds_common-1.0.10.tar.gz", hash = "sha256:ff95bd209648e6b65fa4245ebb3f3d079ce1d86892e5d5478d5a05e5f03d8eec" }
+wheels = [
+    { url = "https://europe-west2-python.pkg.dev/ons-sds-ci/sds-python-packages/sds-common/sds_common-1.0.10-py3-none-any.whl", hash = "sha256:cdd1922cdf450cdb9d060354ba3d7a3bacc8dea04ad3c60285b2efe18bb73dd0" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1297,7 +1297,7 @@ wheels = [
 
 [[package]]
 name = "sds"
-version = "2.2.3"
+version = "2.2.4"
 source = { virtual = "." }
 dependencies = [
     { name = "coverage" },


### PR DESCRIPTION
### Motivation and Context
The Google Cloud Oauth IAP Admin API is being removed on 19th March 2026. We currently use this API to generate authentication tokens for running integration tests. This work removes the need for these APIs by using the existing sds-common libraries `generate_authenticated_headers()` method that generates a token using the existing `iap-secret` stored in Secret Manager. 

### What has changed
- Remove use of Oauth IAP Admin API in `cloudbuild-dev.yaml`
- Add required code changes to generate token within the tests themselves.
- Change deployment of Cloud Run in Cloud Build files to fix for new org policy

### How to test?
- Run integration tests

### Links
Jira Ticket - [DFTS-1540](https://officefornationalstatistics.atlassian.net/browse/DFTS-1540)