### PR TITLE
Isaiah dfts 1556 change sds endpoints name

### DIFF
--- a/.coveragerc_unit
+++ b/.coveragerc_unit
@@ -1,0 +1,4 @@
+[run]
+omit =
+    app/routers/schema_router.py
+    app/routers/dataset_router.py

--- a/.coveragerc_unit_deprecated
+++ b/.coveragerc_unit_deprecated
@@ -1,0 +1,4 @@
+[run]
+omit =
+    app/routers/schema_router_restful.py
+    app/routers/dataset_router_restful.py

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,16 @@ unit-tests:
 	export PROJECT_ID=mock-project-id && \
 	export PUBLISH_SCHEMA_TOPIC_ID=${PUBLISH_SCHEMA_TOPIC_ID} && \
 	export FIRESTORE_DB_NAME="the-firestore-db-name" && \
-	uv run python -m pytest -vv  --cov=app ./tests/unit_tests/ -W ignore::DeprecationWarning
-	uv run python -m coverage report --fail-under=90  -m
+	uv run python -m pytest --cov=app --cov-fail-under=90 --cov-report term-missing --cov-config=.coveragerc_unit -vv ./tests/unit_tests/ -W ignore::DeprecationWarning
+	make unit-tests-deprecated
+
+unit-tests-deprecated:
+	export CONF='unit' && \
+	export PROJECT_ID=mock-project-id && \
+	export PUBLISH_SCHEMA_TOPIC_ID=${PUBLISH_SCHEMA_TOPIC_ID} && \
+	export FIRESTORE_DB_NAME="the-firestore-db-name" && \
+	export ENDPOINTS_DEPRECATED="true" && \
+	uv run python -m pytest --cov=app --cov-fail-under=90 --cov-report term-missing --cov-config=.coveragerc_unit_deprecated -vv ./tests/unit_tests/ -W ignore::DeprecationWarning
 
 # Spinning up emulators in docker is required to run the local integration tests.
 integration-tests-local:

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,19 @@ integration-tests-local:
 	export PUBSUB_EMULATOR_HOST=localhost:8085 && \
 	export FIRESTORE_EMULATOR_HOST=localhost:8080 && \
 	uv run python -m pytest --order-scope=module tests/integration_tests -vv -W ignore::DeprecationWarning
+	make integration-tests-local-deprecated
+
+integration-tests-local-deprecated:
+	export CONF='local-int-tests' && \
+	export PROJECT_ID='mock-project-id' && \
+	export PYTHONPATH=${PYTHONPATH} && \
+	export PUBLISH_SCHEMA_TOPIC_ID='emulated-sds-schema-topic' && \
+	export API_URL=${LOCAL_URL} && \
+	export URL_SCHEME='http' && \
+	export ENDPOINTS_DEPRECATED="true" && \
+	export PUBSUB_EMULATOR_HOST=localhost:8085 && \
+	export FIRESTORE_EMULATOR_HOST=localhost:8080 && \
+	uv run python -m pytest --order-scope=module tests/integration_tests -vv -W ignore::DeprecationWarning
 
 # Please run gcloud auth application-default login before running the following commands that interact with GCP services
 # Please ensure user account has role Service Account Token Creator
@@ -57,6 +70,17 @@ integration-tests-sandbox:
 	export API_URL='${SANDBOX_IP_ADDRESS}.nip.io' && \
 	export FIRESTORE_DB_NAME='${PROJECT_ID}-sds' && \
 	export URL_SCHEME='https' && \
+	export SECRET_ID='iap-secret' && \
+	uv run python -m pytest --order-scope=module tests/integration_tests -vv -W ignore::DeprecationWarning
+
+integration-tests-sandbox-deprecated:
+	export CONF='sandbox-int-tests' && \
+	export PYTHONPATH=${PYTHONPATH} && \
+	export PROJECT_ID=${PROJECT_ID} && \
+	export API_URL='${SANDBOX_IP_ADDRESS}.nip.io' && \
+	export FIRESTORE_DB_NAME='${PROJECT_ID}-sds' && \
+	export URL_SCHEME='https' && \
+	export ENDPOINTS_DEPRECATED="true" && \
 	export SECRET_ID='iap-secret' && \
 	uv run python -m pytest --order-scope=module tests/integration_tests -vv -W ignore::DeprecationWarning
 

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ from fastapi.openapi.utils import get_openapi
 from app.exception import exceptions
 from app.exception.exception_interceptor import ExceptionInterceptor
 from app.logging_config import logging
-from app.routers import dataset_router, schema_router, status_router, dataset_router_restful, schema_router_restful
+from app.routers import dataset_router, dataset_router_restful, schema_router, schema_router_restful, status_router
 
 logger = logging.getLogger(__name__)
 app = FastAPI()

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ from fastapi.openapi.utils import get_openapi
 from app.exception import exceptions
 from app.exception.exception_interceptor import ExceptionInterceptor
 from app.logging_config import logging
-from app.routers import dataset_router, schema_router, status_router
+from app.routers import dataset_router, schema_router, status_router, dataset_router_restful, schema_router_restful
 
 logger = logging.getLogger(__name__)
 app = FastAPI()
@@ -108,5 +108,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 
 
 app.include_router(dataset_router.router)
+app.include_router(dataset_router_restful.router)
 app.include_router(schema_router.router)
+app.include_router(schema_router_restful.router)
 app.include_router(status_router.router)

--- a/app/routers/dataset_router.py
+++ b/app/routers/dataset_router.py
@@ -18,7 +18,7 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-@router.post("/collection-exercise-end", status_code=200)
+@router.post("/collection-exercise-end", status_code=200, deprecated=True)
 async def post_collection_exercise_end_message(
     collection_end_data: CollectionExerciseEndData,
     dataset_deletion_service: DatasetDeletionService = Depends(get_dataset_deletion_service),
@@ -63,6 +63,7 @@ async def post_collection_exercise_end_message(
             },
         },
     },
+    deprecated=True,
 )
 async def get_unit_supplementary_data(
     dataset_id: str,
@@ -117,6 +118,7 @@ async def get_unit_supplementary_data(
             },
         },
     },
+    deprecated=True,
 )
 async def get_dataset_metadata_collection(
     survey_id: str | None = None,
@@ -161,6 +163,7 @@ async def get_dataset_metadata_collection(
             "content": {"application/json": {"example": erm.erm_500_global_exception}},
         },
     },
+    deprecated=True,
 )
 async def get_all_dataset_metadata_collection(
     dataset_service: DatasetService = Depends(get_dataset_service),

--- a/app/routers/dataset_router_restful.py
+++ b/app/routers/dataset_router_restful.py
@@ -18,7 +18,7 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-@router.post("/collection-exercise-end", status_code=200)
+@router.post("/collection-exercises-end", status_code=200)
 async def post_collection_exercise_end_message(
     collection_end_data: CollectionExerciseEndData,
     dataset_deletion_service: DatasetDeletionService = Depends(get_dataset_deletion_service),
@@ -42,7 +42,7 @@ async def post_collection_exercise_end_message(
 
 
 @router.get(
-    "/v1/unit_data",
+    "/datasets/{dataset_id}/unit-data/{identifier}",
     name="Get unit supplementary data",
     response_model=UnitDataset,
     responses={
@@ -94,7 +94,7 @@ async def get_unit_supplementary_data(
 
 
 @router.get(
-    "/v1/dataset_metadata",
+    "/datasets/metadata",
     name="Get dataset metadata",
     response_model=list[DatasetMetadata],
     responses={
@@ -152,7 +152,7 @@ async def get_dataset_metadata_collection(
 
 
 @router.get(
-    "/v1/all_dataset_metadata",
+    "/datasets/all-metadata",
     name="Get all dataset metadata",
     response_model=list[DatasetMetadata],
     responses={

--- a/app/routers/schema_router.py
+++ b/app/routers/schema_router.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
             "content": {"application/json": {"example": erm.erm_500_global_exception}},
         },
     },
+    deprecated=True,
 )
 async def post_schema(
     survey_id: str,
@@ -84,6 +85,7 @@ async def post_schema(
             },
         },
     },
+    deprecated=True,
 )
 async def get_schema(
     survey_id: str | None = None,
@@ -152,6 +154,7 @@ async def get_schema(
             },
         },
     },
+    deprecated=True,
 )
 async def get_schema_with_guid(
     guid: str | None = None,
@@ -206,6 +209,7 @@ async def get_schema_with_guid(
             },
         },
     },
+    deprecated=True,
 )
 async def get_schema_metadata_collection(
     survey_id: str | None = None,
@@ -252,6 +256,7 @@ async def get_schema_metadata_collection(
             },
         },
     },
+    deprecated=True,
 )
 async def get_survey_id_map(
     schema_processor_service: SchemaProcessorService = Depends(get_schema_processor_service),

--- a/app/routers/schema_router_restful.py
+++ b/app/routers/schema_router_restful.py
@@ -213,6 +213,7 @@ async def get_all_schema_metadata_collection(
     return schema_metadata_collection
 
 
+# This endpoint must be placed after the /schemas endpoint to avoid conflicts with the /schemas/{guid} path parameter.
 @router.get(
     "/schemas/{guid}",
     name="Get Schema with GUID",

--- a/app/routers/schema_router_restful.py
+++ b/app/routers/schema_router_restful.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 @router.post(
-    "/v1/schema",
+    "/schemas",
     name="Post Schema",
     response_model=SchemaMetadata,
     responses={
@@ -64,7 +64,7 @@ async def post_schema(
 
 
 @router.get(
-    "/v1/schema",
+    "/schemas",
     name="Get Schema",
     responses={
         400: {
@@ -132,7 +132,89 @@ async def get_schema(
 
 
 @router.get(
-    "/v2/schema",
+    "/schemas/metadata",
+    name="Get Schema Metadata",
+    response_model=list[SchemaMetadata],
+    responses={
+        400: {
+            "model": ExceptionResponseModel,
+            "content": {
+                "application/json": {"example": erm.erm_400_invalid_search_exception}
+            },
+        },
+        500: {
+            "model": ExceptionResponseModel,
+            "content": {"application/json": {"example": erm.erm_500_global_exception}},
+        },
+        404: {
+            "model": ExceptionResponseModel,
+            "content": {
+                "application/json": {"example": erm.erm_404_no_results_exception}
+            },
+        },
+    },
+)
+async def get_schema_metadata_collection(
+    survey_id: str | None = None,
+    schema_processor_service: SchemaProcessorService = Depends(get_schema_processor_service)
+) -> list[SchemaMetadata]:
+    """
+    Get all schema metadata associated with a specific survey id.
+
+    Parameters:
+    survey_id (str): survey id of the collection
+    schema_processor_service (SchemaProcessorService): injected dependency for processing the metadata collection.
+    """
+    QueryParameterValidatorService.validate_survey_id_from_schema_metadata(survey_id)
+
+    logger.info("Getting schemas metadata...")
+    logger.debug(f"Input data: survey_id={survey_id}")
+
+    schema_metadata_collection = (
+        schema_processor_service.get_schema_metadata_collection_with_guid(survey_id)
+    )
+    if not schema_metadata_collection:
+        logger.error("Schemas metadata not found")
+        raise exceptions.ExceptionNoSchemaMetadataCollection
+
+    logger.info("Schemas metadata successfully retrieved.")
+    logger.debug(f"Schemas metadata: {schema_metadata_collection}")
+
+    return schema_metadata_collection
+
+
+@router.get(
+    "/schemas/all-metadata",
+    name="Get All Schema Metadata",
+    response_model=list[SchemaMetadata],
+    responses={
+        500: {
+            "model": ExceptionResponseModel,
+            "content": {"application/json": {"example": erm.erm_500_global_exception}},
+        },
+    },
+)
+async def get_all_schema_metadata_collection(
+    schema_processor_service: SchemaProcessorService = Depends(get_schema_processor_service),
+) -> list[SchemaMetadata]:
+    """Retrieve all schema metadata from the schema collection.
+    """
+    logger.info("Getting all schema metadata collection...")
+
+    schema_metadata_collection = schema_processor_service.get_all_schema_metadata_collection()
+
+    if not schema_metadata_collection:
+        logger.error("Schema metadata collection not found.")
+        raise exceptions.ExceptionNoSchemaMetadataCollection
+
+    logger.info("Schema metadata collection successfully retrieved.")
+    logger.debug(f"Schema metadata collection: {schema_metadata_collection}")
+
+    return schema_metadata_collection
+
+
+@router.get(
+    "/schemas/{guid}",
     name="Get Schema with GUID",
     responses={
         400: {
@@ -185,59 +267,7 @@ async def get_schema_with_guid(
 
 
 @router.get(
-    "/v1/schema_metadata",
-    name="Get Schema Metadata",
-    response_model=list[SchemaMetadata],
-    responses={
-        400: {
-            "model": ExceptionResponseModel,
-            "content": {
-                "application/json": {"example": erm.erm_400_invalid_search_exception}
-            },
-        },
-        500: {
-            "model": ExceptionResponseModel,
-            "content": {"application/json": {"example": erm.erm_500_global_exception}},
-        },
-        404: {
-            "model": ExceptionResponseModel,
-            "content": {
-                "application/json": {"example": erm.erm_404_no_results_exception}
-            },
-        },
-    },
-)
-async def get_schema_metadata_collection(
-    survey_id: str | None = None,
-    schema_processor_service: SchemaProcessorService = Depends(get_schema_processor_service)
-) -> list[SchemaMetadata]:
-    """
-    Get all schema metadata associated with a specific survey id.
-
-    Parameters:
-    survey_id (str): survey id of the collection
-    schema_processor_service (SchemaProcessorService): injected dependency for processing the metadata collection.
-    """
-    QueryParameterValidatorService.validate_survey_id_from_schema_metadata(survey_id)
-
-    logger.info("Getting schemas metadata...")
-    logger.debug(f"Input data: survey_id={survey_id}")
-
-    schema_metadata_collection = (
-        schema_processor_service.get_schema_metadata_collection_with_guid(survey_id)
-    )
-    if not schema_metadata_collection:
-        logger.error("Schemas metadata not found")
-        raise exceptions.ExceptionNoSchemaMetadataCollection
-
-    logger.info("Schemas metadata successfully retrieved.")
-    logger.debug(f"Schemas metadata: {schema_metadata_collection}")
-
-    return schema_metadata_collection
-
-
-@router.get(
-    "/v1/survey_list",
+    "/surveys",
     name="Get Survey Mapping",
     response_model=list[dict],
     responses={
@@ -267,33 +297,3 @@ async def get_survey_id_map(
         logger.error("No Survey IDs found")
         raise exceptions.ExceptionNoSurveyIDs
     return survey_id_map
-
-
-@router.get(
-    "/v1/all_schema_metadata",
-    name="Get All Schema Metadata",
-    response_model=list[SchemaMetadata],
-    responses={
-        500: {
-            "model": ExceptionResponseModel,
-            "content": {"application/json": {"example": erm.erm_500_global_exception}},
-        },
-    },
-)
-async def get_all_schema_metadata_collection(
-    schema_processor_service: SchemaProcessorService = Depends(get_schema_processor_service),
-) -> list[SchemaMetadata]:
-    """Retrieve all schema metadata from the schema collection.
-    """
-    logger.info("Getting all schema metadata collection...")
-
-    schema_metadata_collection = schema_processor_service.get_all_schema_metadata_collection()
-
-    if not schema_metadata_collection:
-        logger.error("Schema metadata collection not found.")
-        raise exceptions.ExceptionNoSchemaMetadataCollection
-
-    logger.info("Schema metadata collection successfully retrieved.")
-    logger.debug(f"Schema metadata collection: {schema_metadata_collection}")
-
-    return schema_metadata_collection

--- a/cloudbuild-dev.yaml
+++ b/cloudbuild-dev.yaml
@@ -69,7 +69,7 @@ steps:
       ]
 
   - name: python:3.13
-    id: "Run integration test"
+    id: "Run integration test on new endpoints"
     entrypoint: sh
     args:
       - "-c"
@@ -83,6 +83,27 @@ steps:
         export FIRESTORE_DB_NAME=${_FIRESTORE_DB_NAME}
         export SECRET_ID=iap-secret
         export URL_SCHEME=''
+        pip install --upgrade pip --user
+        pip install uv
+        uv sync
+        uv run python -m pytest --order-scope=module tests/integration_tests -vv -W ignore::DeprecationWarning
+
+  - name: python:3.13
+    id: "Run integration test on deprecated endpoints"
+    entrypoint: sh
+    args:
+      - "-c"
+      - |
+        export CONF='cloudbuild-int-tests'
+        export LOG_LEVEL=${_LOG_LEVEL}
+        export PROJECT_ID=${PROJECT_ID}
+        export PUBLISH_SCHEMA_TOPIC_ID=${_PUBLISH_SCHEMA_TOPIC_ID}
+        export API_URL=${_API_URL}
+        export SURVEY_MAP_URL=${_SURVEY_MAP_URL}
+        export FIRESTORE_DB_NAME=${_FIRESTORE_DB_NAME}
+        export SECRET_ID=iap-secret
+        export URL_SCHEME=''
+        export ENDPOINTS_DEPRECATED='true'
         pip install --upgrade pip --user
         pip install uv
         uv sync

--- a/devtools/SDS - Endpoints Tester - Deprecated.postman_collection.json
+++ b/devtools/SDS - Endpoints Tester - Deprecated.postman_collection.json
@@ -1,9 +1,9 @@
 {
   "info": {
-    "_postman_id": "36413b75-d39d-454a-bcda-8d0fe0a212ac",
-    "name": "SDS - Local Docker",
+    "_postman_id": "b7d16013-9961-4353-bac8-b7b30f2ddd53",
+    "name": "SDS - Endpoints Tester - Deprecated",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "_exporter_id": "30975257"
+    "_exporter_id": "27074658"
   },
   "item": [
     {
@@ -21,11 +21,11 @@
           }
         },
         "url": {
-          "raw": "http://127.0.0.1:3033/v1/schema?survey_id=068",
-          "protocol": "http",
-          "host": ["127", "0", "0", "1"],
-          "port": "3033",
-          "path": ["v1", "schema"],
+          "raw": "{{PROTOCOL}}://{{IP_ADDRESS}}{{POST_SCHEMA_URL}}?survey_id=068",
+          "protocol": "{{PROTOCOL}}",
+          "host": [
+            "{{IP_ADDRESS}}{{POST_SCHEMA_URL}}"
+          ],
           "query": [
             {
               "key": "survey_id",
@@ -42,11 +42,11 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "http://127.0.0.1:3033/v1/schema_metadata?survey_id=068",
-          "protocol": "http",
-          "host": ["127", "0", "0", "1"],
-          "port": "3033",
-          "path": ["v1", "schema_metadata"],
+          "raw": "{{PROTOCOL}}://{{IP_ADDRESS}}{{GET_SCHEMA_METADATA_URL}}?survey_id=068",
+          "protocol": "{{PROTOCOL}}",
+          "host": [
+            "{{IP_ADDRESS}}{{GET_SCHEMA_METADATA_URL}}"
+          ],
           "query": [
             {
               "key": "survey_id",
@@ -57,28 +57,20 @@
       },
       "response": []
     },
-        {
+    {
       "name": "All Schema Metadata",
       "request": {
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "http://127.0.0.1:3033/v1/all_schema_metadata",
-          "protocol": "http",
+          "raw": "{{PROTOCOL}}://{{IP_ADDRESS}}{{GET_ALL_SCHEMA_METADATA_URL}}",
+          "protocol": "{{PROTOCOL}}",
           "host": [
-            "127",
-            "0",
-            "0",
-            "1"
-          ],
-          "port": "3033",
-          "path": [
-            "v1",
-            "all_schema_metadata"
-          ],
-          "response": []
+            "{{IP_ADDRESS}}{{GET_ALL_SCHEMA_METADATA_URL}}"
+          ]
         }
-      }
+      },
+      "response": []
     },
     {
       "name": "Schema",
@@ -86,11 +78,11 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "http://127.0.0.1:3033/v1/schema?survey_id=068&version=1",
-          "protocol": "http",
-          "host": ["127", "0", "0", "1"],
-          "port": "3033",
-          "path": ["v1", "schema"],
+          "raw": "{{PROTOCOL}}://{{IP_ADDRESS}}{{GET_SCHEMA_URL}}?survey_id=068&version=1",
+          "protocol": "{{PROTOCOL}}",
+          "host": [
+            "{{IP_ADDRESS}}{{GET_SCHEMA_URL}}"
+          ],
           "query": [
             {
               "key": "survey_id",
@@ -111,15 +103,15 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "http://127.0.0.1:3033/v2/schema?guid=a51a2d0f-8398-4b73-a4e7-528edd918a7f",
-          "protocol": "http",
-          "host": ["127", "0", "0", "1"],
-          "port": "3033",
-          "path": ["v2", "schema"],
+          "raw": "{{PROTOCOL}}://{{IP_ADDRESS}}{{GET_SCHEMA_WITH_GUID_URL}}?guid=7bdfd988-0c77-4bd5-b678-7279acb3ed36",
+          "protocol": "{{PROTOCOL}}",
+          "host": [
+            "{{IP_ADDRESS}}{{GET_SCHEMA_WITH_GUID_URL}}"
+          ],
           "query": [
             {
               "key": "guid",
-              "value": "a51a2d0f-8398-4b73-a4e7-528edd918a7f"
+              "value": "7bdfd988-0c77-4bd5-b678-7279acb3ed36"
             }
           ]
         }
@@ -132,19 +124,19 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "http://127.0.0.1:3033/v1/dataset_metadata?survey_id=NRX&period_id=ttt",
-          "protocol": "http",
-          "host": ["127", "0", "0", "1"],
-          "port": "3033",
-          "path": ["v1", "dataset_metadata"],
+          "raw": "{{PROTOCOL}}://{{IP_ADDRESS}}{{GET_DATASET_METADATA_URL}}?survey_id=068&period_id=211024",
+          "protocol": "{{PROTOCOL}}",
+          "host": [
+            "{{IP_ADDRESS}}{{GET_DATASET_METADATA_URL}}"
+          ],
           "query": [
             {
               "key": "survey_id",
-              "value": "NRX"
+              "value": "068"
             },
             {
               "key": "period_id",
-              "value": "ttt"
+              "value": "211024"
             }
           ]
         }
@@ -157,22 +149,14 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "http://127.0.0.1:3033/v1/all_dataset_metadata",
-          "protocol": "http",
+          "raw": "{{PROTOCOL}}://{{IP_ADDRESS}}{{GET_ALL_DATASET_METADATA_URL}}",
+          "protocol": "{{PROTOCOL}}",
           "host": [
-            "127",
-            "0",
-            "0",
-            "1"
-          ],
-          "port": "3033",
-          "path": [
-            "v1",
-            "all_dataset_metadata"
-          ],
-          "response": []
+            "{{IP_ADDRESS}}{{GET_ALL_DATASET_METADATA_URL}}"
+          ]
         }
-      }
+      },
+      "response": []
     },
     {
       "name": "Dataset Unit Data",
@@ -180,19 +164,19 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "http://127.0.0.1:3033/v1/unit_data?dataset_id=2485372e-f2ac-4fb7-9c08-588b8ed26b53&identifier=43532",
-          "protocol": "http",
-          "host": ["127", "0", "0", "1"],
-          "port": "3033",
-          "path": ["v1", "unit_data"],
+          "raw": "{{PROTOCOL}}://{{IP_ADDRESS}}{{GET_UNIT_DATA_URL}}?dataset_id=11a60c33-849e-4722-9d87-ad9e403d95ea&identifier=11275510298",
+          "protocol": "{{PROTOCOL}}",
+          "host": [
+            "{{IP_ADDRESS}}{{GET_UNIT_DATA_URL}}"
+          ],
           "query": [
             {
               "key": "dataset_id",
-              "value": "2485372e-f2ac-4fb7-9c08-588b8ed26b53"
+              "value": "11a60c33-849e-4722-9d87-ad9e403d95ea"
             },
             {
               "key": "identifier",
-              "value": "43532"
+              "value": "11275510298"
             }
           ]
         }
@@ -207,9 +191,17 @@
         "url": {
           "raw": "http://127.0.0.1:3033/v1/survey_list",
           "protocol": "http",
-          "host": ["127", "0", "0", "1"],
+          "host": [
+            "127",
+            "0",
+            "0",
+            "1"
+          ],
           "port": "3033",
-          "path": ["v1", "survey_list"]
+          "path": [
+            "v1",
+            "survey_list"
+          ]
         }
       },
       "response": []
@@ -222,12 +214,119 @@
         "url": {
           "raw": "http://127.0.0.1:3033/status",
           "protocol": "http",
-          "host": ["127", "0", "0", "1"],
+          "host": [
+            "127",
+            "0",
+            "0",
+            "1"
+          ],
           "port": "3033",
-          "path": ["status"]
+          "path": [
+            "status"
+          ]
         }
       },
       "response": []
+    },
+    {
+      "name": "Collection Exercises End",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"dataset_guid\": \"11a60c33-849e-4722-9d87-ad9e403d95ea\",\n    \"survey_id\": \"068\",\n    \"period_id\": \"211024\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{PROTOCOL}}://{{IP_ADDRESS}}{{COLLECTION_EXERCISE_END_URL}}",
+          "protocol": "{{PROTOCOL}}",
+          "host": [
+            "{{IP_ADDRESS}}{{COLLECTION_EXERCISE_END_URL}}"
+          ]
+        }
+      },
+      "response": []
+    }
+  ],
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "PROTOCOL",
+      "value": "",
+      "description": "http or https"
+    },
+    {
+      "key": "IP_ADDRESS",
+      "value": "",
+      "description": "IP Address of SDS"
+    },
+    {
+      "key": "POST_SCHEMA_URL",
+      "value": ""
+    },
+    {
+      "key": "GET_SCHEMA_URL",
+      "value": ""
+    },
+    {
+      "key": "GET_SCHEMA_WITH_GUID_URL",
+      "value": ""
+    },
+    {
+      "key": "GET_DATASET_METADATA_URL",
+      "value": ""
+    },
+    {
+      "key": "GET_UNIT_DATA_URL",
+      "value": ""
+    },
+    {
+      "key": "GET_ALL_SCHEMA_METADATA_URL",
+      "value": ""
+    },
+    {
+      "key": "GET_ALL_DATASET_METADATA_URL",
+      "value": ""
+    },
+    {
+      "key": "GET_SURVEYS_URL",
+      "value": ""
+    },
+    {
+      "key": "GET_SCHEMA_METADATA_URL",
+      "value": ""
+    },
+    {
+      "key": "COLLECTION_EXERCISE_END_URL",
+      "value": ""
     }
   ]
 }

--- a/devtools/SDS - Endpoints Tester.postman_collection.json
+++ b/devtools/SDS - Endpoints Tester.postman_collection.json
@@ -1,0 +1,325 @@
+{
+  "info": {
+    "_postman_id": "4bc4e9f6-a261-4da0-9956-432fcb154942",
+    "name": "SDS - Endpoints Tester",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "27074658"
+  },
+  "item": [
+    {
+      "name": "Publish Schema",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n  \"$id\": \"roofing_tiles_and_slate.json\",\n  \"title\": \"SDS schema for the Roofing Tiles + Slate survey\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"schema_version\": {\n      \"const\": \"v1\",\n      \"description\": \"Version of the schema spec\"\n    },\n    \"identifier\": {\n      \"type\": \"string\",\n      \"description\": \"The unique top-level identifier. This is the reporting unit reference without the check letter appended\",\n      \"minLength\": 11,\n      \"pattern\": \"^[a-zA-Z0-9]+$\",\n      \"examples\": [\"34942807969\"]\n    },\n    \"items\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"local_units\": {\n          \"type\": \"array\",\n          \"description\": \"The data about each item\",\n          \"minItems\": 1,\n          \"uniqueItems\": true,\n          \"items\": {\n            \"type\": \"object\",\n            \"properties\": {\n              \"identifier\": {\n                \"type\": \"string\",\n                \"minLength\": 1,\n                \"description\": \"The unique identifier for the items. This is the local unit reference.\",\n                \"examples\": [\"3340224\"]\n              },\n              \"lu_name\": {\n                \"type\": \"string\",\n                \"minLength\": 1,\n                \"description\": \"Name of the local unit\",\n                \"examples\": [\"STUBBS BUILDING PRODUCTS LTD\"]\n              },\n              \"lu_address\": {\n                \"type\": \"array\",\n                \"description\": \"The fields of the address for the local unit\",\n                \"items\": {\n                  \"type\": \"string\",\n                  \"minLength\": 1\n                },\n                \"minItems\": 1,\n                \"uniqueItems\": true,\n                \"examples\": [\n                  [\n                    \"WELLINGTON ROAD\",\n                    \"LOCHMABEN\",\n                    \"SWINDON\",\n                    \"BEDS\",\n                    \"GLOS\",\n                    \"DE41 2WA\"\n                  ]\n                ]\n              }\n            },\n            \"additionalProperties\": false,\n            \"required\": [\"identifier\", \"lu_name\", \"lu_address\"]\n          }\n        }\n      },\n      \"additionalProperties\": false,\n      \"required\": [\"local_units\"]\n    }\n  },\n  \"additionalProperties\": false,\n  \"required\": [\"schema_version\", \"identifier\", \"items\"]\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{PROTOCOL}}://{{IP_ADDRESS}}{{POST_SCHEMA_URL}}?survey_id=068",
+          "protocol": "{{PROTOCOL}}",
+          "host": [
+            "{{IP_ADDRESS}}{{POST_SCHEMA_URL}}"
+          ],
+          "query": [
+            {
+              "key": "survey_id",
+              "value": "068"
+            }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Schema Metadata",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{PROTOCOL}}://{{IP_ADDRESS}}{{GET_SCHEMA_METADATA_URL}}?survey_id=068",
+          "protocol": "{{PROTOCOL}}",
+          "host": [
+            "{{IP_ADDRESS}}{{GET_SCHEMA_METADATA_URL}}"
+          ],
+          "query": [
+            {
+              "key": "survey_id",
+              "value": "068"
+            }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "All Schema Metadata",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{PROTOCOL}}://{{IP_ADDRESS}}{{GET_ALL_SCHEMA_METADATA_URL}}",
+          "protocol": "{{PROTOCOL}}",
+          "host": [
+            "{{IP_ADDRESS}}{{GET_ALL_SCHEMA_METADATA_URL}}"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Schema",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{PROTOCOL}}://{{IP_ADDRESS}}{{GET_SCHEMA_URL}}?survey_id=068&version=1",
+          "protocol": "{{PROTOCOL}}",
+          "host": [
+            "{{IP_ADDRESS}}{{GET_SCHEMA_URL}}"
+          ],
+          "query": [
+            {
+              "key": "survey_id",
+              "value": "068"
+            },
+            {
+              "key": "version",
+              "value": "1"
+            }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "v2 Schema",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{PROTOCOL}}://{{IP_ADDRESS}}{{GET_SCHEMA_WITH_GUID_URL}}/7bdfd988-0c77-4bd5-b678-7279acb3ed36",
+          "protocol": "{{PROTOCOL}}",
+          "host": [
+            "{{IP_ADDRESS}}{{GET_SCHEMA_WITH_GUID_URL}}"
+          ],
+          "path": [
+            "7bdfd988-0c77-4bd5-b678-7279acb3ed36"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Dataset Metadata",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{PROTOCOL}}://{{IP_ADDRESS}}{{GET_DATASET_METADATA_URL}}?survey_id=068&period_id=211024",
+          "protocol": "{{PROTOCOL}}",
+          "host": [
+            "{{IP_ADDRESS}}{{GET_DATASET_METADATA_URL}}"
+          ],
+          "query": [
+            {
+              "key": "survey_id",
+              "value": "068"
+            },
+            {
+              "key": "period_id",
+              "value": "211024"
+            }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "All Dataset Metadata",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{PROTOCOL}}://{{IP_ADDRESS}}{{GET_ALL_DATASET_METADATA_URL}}",
+          "protocol": "{{PROTOCOL}}",
+          "host": [
+            "{{IP_ADDRESS}}{{GET_ALL_DATASET_METADATA_URL}}"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Dataset Unit Data",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{PROTOCOL}}://{{IP_ADDRESS}}/datasets/11a60c33-849e-4722-9d87-ad9e403d95ea/unit-data/11275510298",
+          "protocol": "{{PROTOCOL}}",
+          "host": [
+            "{{IP_ADDRESS}}"
+          ],
+          "path": [
+            "datasets",
+            "11a60c33-849e-4722-9d87-ad9e403d95ea",
+            "unit-data",
+            "11275510298"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Survey List",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://127.0.0.1:3033/v1/survey_list",
+          "protocol": "http",
+          "host": [
+            "127",
+            "0",
+            "0",
+            "1"
+          ],
+          "port": "3033",
+          "path": [
+            "v1",
+            "survey_list"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Status",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://127.0.0.1:3033/status",
+          "protocol": "http",
+          "host": [
+            "127",
+            "0",
+            "0",
+            "1"
+          ],
+          "port": "3033",
+          "path": [
+            "status"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Collection Exercises End",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"dataset_guid\": \"11a60c33-849e-4722-9d87-ad9e403d95ea\",\n    \"survey_id\": \"068\",\n    \"period_id\": \"211024\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{PROTOCOL}}://{{IP_ADDRESS}}{{COLLECTION_EXERCISE_END_URL}}",
+          "protocol": "{{PROTOCOL}}",
+          "host": [
+            "{{IP_ADDRESS}}{{COLLECTION_EXERCISE_END_URL}}"
+          ]
+        }
+      },
+      "response": []
+    }
+  ],
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "PROTOCOL",
+      "value": "",
+      "description": "http or https"
+    },
+    {
+      "key": "IP_ADDRESS",
+      "value": "",
+      "description": "IP Address of SDS"
+    },
+    {
+      "key": "POST_SCHEMA_URL",
+      "value": ""
+    },
+    {
+      "key": "GET_SCHEMA_URL",
+      "value": ""
+    },
+    {
+      "key": "GET_SCHEMA_WITH_GUID_URL",
+      "value": ""
+    },
+    {
+      "key": "GET_DATASET_METADATA_URL",
+      "value": ""
+    },
+    {
+      "key": "GET_UNIT_DATA_URL",
+      "value": ""
+    },
+    {
+      "key": "GET_ALL_SCHEMA_METADATA_URL",
+      "value": ""
+    },
+    {
+      "key": "GET_ALL_DATASET_METADATA_URL",
+      "value": ""
+    },
+    {
+      "key": "GET_SURVEYS_URL",
+      "value": ""
+    },
+    {
+      "key": "GET_SCHEMA_METADATA_URL",
+      "value": ""
+    },
+    {
+      "key": "COLLECTION_EXERCISE_END_URL",
+      "value": ""
+    }
+  ]
+}

--- a/gateway/openapi.yaml
+++ b/gateway/openapi.yaml
@@ -7,6 +7,23 @@ paths:
   /collection-exercise-end:
     post:
       summary: Post Collection Exercise End Message
+      description: 'Endpoint to receive collection exercise end message, process the
+        message and mark datasets for deletion
+
+        if dataset_guid is present in the message.
+
+
+        Parameters:
+
+        collection_end_data (CollectionExerciseEndData): The collection exercise end
+        message body, containing the GUID
+
+        of the dataset to be deleted and the survey_id and period id to find the relevant
+        dataset metadata for deletion.
+
+
+        This endpoint is currently not being used and is partially built without implementation
+        of unhappy path'
       operationId: post_collection_exercise_end_message_collection_exercise_end_post
       requestBody:
         content:
@@ -20,6 +37,7 @@ paths:
           content:
             application/json:
               schema: {}
+      deprecated: true
   /v1/unit_data:
     get:
       summary: Get Unit Supplementary Data
@@ -33,7 +51,8 @@ paths:
 
         identifier (str): The identifier of the particular unit on the data being
         queried.'
-      operationId: get_unit_supplementary_data_v1_unit_data_get
+      operationId: Get_unit_supplementary_data_v1_unit_data_get
+      deprecated: true
       parameters:
       - name: dataset_id
         in: query
@@ -52,7 +71,8 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/UnitDataset'
         '400':
           content:
             application/json:
@@ -82,7 +102,7 @@ paths:
           description: Not Found
   /v1/dataset_metadata:
     get:
-      summary: Get Dataset Metadata Collection
+      summary: Get Dataset Metadata
       description: 'Retrieve the matching dataset metadata, given the survey_id and
         period_id.
 
@@ -92,7 +112,8 @@ paths:
         survey_id (str): The survey id of the dataset being queried.
 
         period_id (str): The period id of the dataset being queried.'
-      operationId: get_dataset_metadata_collection_v1_dataset_metadata_get
+      operationId: Get_dataset_metadata_v1_dataset_metadata_get
+      deprecated: true
       parameters:
       - name: survey_id
         in: query
@@ -119,8 +140,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/DatasetMetadata'
-                title: Response Get Dataset Metadata Collection V1 Dataset Metadata
-                  Get
+                title: Response Get Dataset Metadata V1 Dataset Metadata Get
         '400':
           content:
             application/json:
@@ -150,9 +170,9 @@ paths:
           description: Not Found
   /v1/all_dataset_metadata:
     get:
-      summary: Get All Dataset Metadata Collection
+      summary: Get All Dataset Metadata
       description: Retrieve all dataset metadata.
-      operationId: get_all_dataset_metadata_collection_v1_all_dataset_metadata_get
+      operationId: Get_all_dataset_metadata_v1_all_dataset_metadata_get
       responses:
         '200':
           description: Successful Response
@@ -162,8 +182,193 @@ paths:
                 items:
                   $ref: '#/components/schemas/DatasetMetadata'
                 type: array
-                title: Response Get All Dataset Metadata Collection V1 All Dataset
-                  Metadata Get
+                title: Response Get All Dataset Metadata V1 All Dataset Metadata Get
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExceptionResponseModel'
+              example:
+                status: error
+                message: Unable to process request
+      deprecated: true
+  /collection-exercises-end:
+    post:
+      summary: Post Collection Exercise End Message
+      description: 'Endpoint to receive collection exercise end message, process the
+        message and mark datasets for deletion
+
+        if dataset_guid is present in the message.
+
+
+        Parameters:
+
+        collection_end_data (CollectionExerciseEndData): The collection exercise end
+        message body, containing the GUID
+
+        of the dataset to be deleted and the survey_id and period id to find the relevant
+        dataset metadata for deletion.
+
+
+        This endpoint is currently not being used and is partially built without implementation
+        of unhappy path'
+      operationId: post_collection_exercise_end_message_collection_exercises_end_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CollectionExerciseEndData'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+  /datasets/{dataset_id}/unit-data/{identifier}:
+    get:
+      summary: Get Unit Supplementary Data
+      description: 'Retrieve supplementary data for a particular unit given the dataset
+        id and identifier, return 404 if no data is returned.
+
+
+        Parameters:
+
+        dataset_id (str): The unique id of the dataset being queried.
+
+        identifier (str): The identifier of the particular unit on the data being
+        queried.'
+      operationId: Get_unit_supplementary_data_datasets__dataset_id__unit_data__identifier__get
+      parameters:
+      - name: dataset_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Dataset Id
+      - name: identifier
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Identifier
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnitDataset'
+        '400':
+          content:
+            application/json:
+              example:
+                status: error
+                message: Validation has failed
+              schema:
+                $ref: '#/components/schemas/ExceptionResponseModel'
+          description: Bad Request
+        '500':
+          content:
+            application/json:
+              example:
+                status: error
+                message: Unable to process request
+              schema:
+                $ref: '#/components/schemas/ExceptionResponseModel'
+          description: Internal Server Error
+        '404':
+          content:
+            application/json:
+              example:
+                status: error
+                message: No unit data found
+              schema:
+                $ref: '#/components/schemas/ExceptionResponseModel'
+          description: Not Found
+  /datasets/metadata:
+    get:
+      summary: Get Dataset Metadata
+      description: 'Retrieve the matching dataset metadata, given the survey_id and
+        period_id.
+
+
+        Parameters:
+
+        survey_id (str): The survey id of the dataset being queried.
+
+        period_id (str): The period id of the dataset being queried.'
+      operationId: Get_dataset_metadata_datasets_metadata_get
+      parameters:
+      - name: survey_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Survey Id
+      - name: period_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Period Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DatasetMetadata'
+                title: Response Get Dataset Metadata Datasets Metadata Get
+        '400':
+          content:
+            application/json:
+              example:
+                status: error
+                message: Invalid search parameters provided
+              schema:
+                $ref: '#/components/schemas/ExceptionResponseModel'
+          description: Bad Request
+        '500':
+          content:
+            application/json:
+              example:
+                status: error
+                message: Unable to process request
+              schema:
+                $ref: '#/components/schemas/ExceptionResponseModel'
+          description: Internal Server Error
+        '404':
+          content:
+            application/json:
+              example:
+                status: error
+                message: No datasets found
+              schema:
+                $ref: '#/components/schemas/ExceptionResponseModel'
+          description: Not Found
+  /datasets/all-metadata:
+    get:
+      summary: Get All Dataset Metadata
+      description: Retrieve all dataset metadata.
+      operationId: Get_all_dataset_metadata_datasets_all_metadata_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/DatasetMetadata'
+                type: array
+                title: Response Get All Dataset Metadata Datasets All Metadata Get
         '500':
           description: Internal Server Error
           content:
@@ -187,7 +392,8 @@ paths:
 
         schema_processor_service (SchemaProcessorService): injected processor service
         for processing the schema.'
-      operationId: post_schema_v1_schema_post
+      operationId: Post_Schema_v1_schema_post
+      deprecated: true
       parameters:
       - name: survey_id
         in: query
@@ -237,7 +443,8 @@ paths:
         \ (SchemaFirebaseRepository): injected dependency for\n    interacting with\
         \ the schema collection in firestore.\nschema_processor_service (SchemaProcessorService):\
         \ injected dependency for\n    interacting with the schema collection in firestore."
-      operationId: get_schema_v1_schema_get
+      operationId: Get_Schema_v1_schema_get
+      deprecated: true
       parameters:
       - name: survey_id
         in: query
@@ -299,7 +506,8 @@ paths:
         \ injected dependency for\n    interacting with the schema collection in firestore.\n\
         schema_processor_service (SchemaProcessorService): injected dependency for\n\
         \    interacting with the schema collection in firestore."
-      operationId: get_schema_with_guid_v2_schema_get
+      operationId: Get_Schema_with_GUID_v2_schema_get
+      deprecated: true
       parameters:
       - name: guid
         in: query
@@ -347,7 +555,7 @@ paths:
           description: Not Found
   /v1/schema_metadata:
     get:
-      summary: Get Schema Metadata Collection
+      summary: Get Schema Metadata
       description: 'Get all schema metadata associated with a specific survey id.
 
 
@@ -357,7 +565,8 @@ paths:
 
         schema_processor_service (SchemaProcessorService): injected dependency for
         processing the metadata collection.'
-      operationId: get_schema_metadata_collection_v1_schema_metadata_get
+      operationId: Get_Schema_Metadata_v1_schema_metadata_get
+      deprecated: true
       parameters:
       - name: survey_id
         in: query
@@ -376,8 +585,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/SchemaMetadata'
-                title: Response Get Schema Metadata Collection V1 Schema Metadata
-                  Get
+                title: Response Get Schema Metadata V1 Schema Metadata Get
         '400':
           content:
             application/json:
@@ -407,7 +615,7 @@ paths:
           description: Not Found
   /v1/survey_list:
     get:
-      summary: Get Survey Id Map
+      summary: Get Survey Mapping
       description: 'Gets the Survey mapping data from the survey_map.json file in
         GitHub repository.
 
@@ -415,7 +623,7 @@ paths:
 
         schema_processor_service (SchemaProcessorService): injected dependency for
         processing the survey_map.json file.'
-      operationId: get_survey_id_map_v1_survey_list_get
+      operationId: Get_Survey_Mapping_v1_survey_list_get
       responses:
         '200':
           description: Successful Response
@@ -426,7 +634,7 @@ paths:
                   additionalProperties: true
                   type: object
                 type: array
-                title: Response Get Survey Id Map V1 Survey List Get
+                title: Response Get Survey Mapping V1 Survey List Get
         '500':
           description: Internal Server Error
           content:
@@ -445,11 +653,12 @@ paths:
               example:
                 status: error
                 message: No Survey IDs found
+      deprecated: true
   /v1/all_schema_metadata:
     get:
-      summary: Get All Schema Metadata Collection
+      summary: Get All Schema Metadata
       description: Retrieve all schema metadata from the schema collection.
-      operationId: get_all_schema_metadata_collection_v1_all_schema_metadata_get
+      operationId: Get_All_Schema_Metadata_v1_all_schema_metadata_get
       responses:
         '200':
           description: Successful Response
@@ -459,8 +668,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/SchemaMetadata'
                 type: array
-                title: Response Get All Schema Metadata Collection V1 All Schema Metadata
-                  Get
+                title: Response Get All Schema Metadata V1 All Schema Metadata Get
         '500':
           description: Internal Server Error
           content:
@@ -470,6 +678,301 @@ paths:
               example:
                 status: error
                 message: Unable to process request
+  /schemas:
+    post:
+      summary: Post Schema
+      description: 'Posts the schema metadata to be processed.
+
+
+        Parameters:
+
+        survey_id (str): survey_id of the schema
+
+        schema (dict): schema to be processed in JSON format.
+
+        schema_processor_service (SchemaProcessorService): injected processor service
+        for processing the schema.'
+      operationId: Post_Schema_schemas_post
+      parameters:
+      - name: survey_id
+        in: query
+        required: true
+        schema:
+          type: string
+          title: Survey Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+              title: Schema
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SchemaMetadata'
+        '400':
+          content:
+            application/json:
+              example:
+                status: error
+                message: Validation has failed
+              schema:
+                $ref: '#/components/schemas/ExceptionResponseModel'
+          description: Bad Request
+        '500':
+          content:
+            application/json:
+              example:
+                status: error
+                message: Unable to process request
+              schema:
+                $ref: '#/components/schemas/ExceptionResponseModel'
+          description: Internal Server Error
+    get:
+      summary: Get Schema
+      description: "Gets the guid with specific survey id and version and uses that\
+        \ to retrieve a schema.\nLatest version schema will be retrieved if version\
+        \ is omitted\n\nParameters:\nsurvey_id (str): survey id of the schema metadata.\n\
+        version (str) (optional): version of the survey.\nschema_firebase_repository\
+        \ (SchemaFirebaseRepository): injected dependency for\n    interacting with\
+        \ the schema collection in firestore.\nschema_processor_service (SchemaProcessorService):\
+        \ injected dependency for\n    interacting with the schema collection in firestore."
+      operationId: Get_Schema_schemas_get
+      parameters:
+      - name: survey_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Survey Id
+      - name: version
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Version
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Get Schema Schemas Get
+        '400':
+          content:
+            application/json:
+              example:
+                status: error
+                message: Invalid search provided
+              schema:
+                $ref: '#/components/schemas/ExceptionResponseModel'
+          description: Bad Request
+        '500':
+          content:
+            application/json:
+              example:
+                status: error
+                message: Unable to process request
+              schema:
+                $ref: '#/components/schemas/ExceptionResponseModel'
+          description: Internal Server Error
+        '404':
+          content:
+            application/json:
+              example:
+                status: error
+                message: No schema found
+              schema:
+                $ref: '#/components/schemas/ExceptionResponseModel'
+          description: Not Found
+  /schemas/metadata:
+    get:
+      summary: Get Schema Metadata
+      description: 'Get all schema metadata associated with a specific survey id.
+
+
+        Parameters:
+
+        survey_id (str): survey id of the collection
+
+        schema_processor_service (SchemaProcessorService): injected dependency for
+        processing the metadata collection.'
+      operationId: Get_Schema_Metadata_schemas_metadata_get
+      parameters:
+      - name: survey_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Survey Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SchemaMetadata'
+                title: Response Get Schema Metadata Schemas Metadata Get
+        '400':
+          content:
+            application/json:
+              example:
+                status: error
+                message: Invalid search provided
+              schema:
+                $ref: '#/components/schemas/ExceptionResponseModel'
+          description: Bad Request
+        '500':
+          content:
+            application/json:
+              example:
+                status: error
+                message: Unable to process request
+              schema:
+                $ref: '#/components/schemas/ExceptionResponseModel'
+          description: Internal Server Error
+        '404':
+          content:
+            application/json:
+              example:
+                status: error
+                message: No results found
+              schema:
+                $ref: '#/components/schemas/ExceptionResponseModel'
+          description: Not Found
+  /schemas/all-metadata:
+    get:
+      summary: Get All Schema Metadata
+      description: Retrieve all schema metadata from the schema collection.
+      operationId: Get_All_Schema_Metadata_schemas_all_metadata_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/SchemaMetadata'
+                type: array
+                title: Response Get All Schema Metadata Schemas All Metadata Get
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExceptionResponseModel'
+              example:
+                status: error
+                message: Unable to process request
+  /schemas/{guid}:
+    get:
+      summary: Get Schema With Guid
+      description: "Use the guid to retrieve a schema directly\n\nParameters:\nguid\
+        \ (str): GUID of the schema.\nschema_firebase_repository (SchemaFirebaseRepository):\
+        \ injected dependency for\n    interacting with the schema collection in firestore.\n\
+        schema_processor_service (SchemaProcessorService): injected dependency for\n\
+        \    interacting with the schema collection in firestore."
+      operationId: Get_Schema_with_GUID_schemas__guid__get
+      parameters:
+      - name: guid
+        in: path
+        required: true
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Guid
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Get Schema With Guid Schemas  Guid  Get
+        '400':
+          content:
+            application/json:
+              example:
+                status: error
+                message: Invalid parameter provided
+              schema:
+                $ref: '#/components/schemas/ExceptionResponseModel'
+          description: Bad Request
+        '500':
+          content:
+            application/json:
+              example:
+                status: error
+                message: Unable to process request
+              schema:
+                $ref: '#/components/schemas/ExceptionResponseModel'
+          description: Internal Server Error
+        '404':
+          content:
+            application/json:
+              example:
+                status: error
+                message: No schema found
+              schema:
+                $ref: '#/components/schemas/ExceptionResponseModel'
+          description: Not Found
+  /surveys:
+    get:
+      summary: Get Survey Mapping
+      description: 'Gets the Survey mapping data from the survey_map.json file in
+        GitHub repository.
+
+        Parameters:
+
+        schema_processor_service (SchemaProcessorService): injected dependency for
+        processing the survey_map.json file.'
+      operationId: Get_Survey_Mapping_surveys_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  additionalProperties: true
+                  type: object
+                type: array
+                title: Response Get Survey Mapping Surveys Get
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExceptionResponseModel'
+              example:
+                status: error
+                message: Unable to process request
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExceptionResponseModel'
+              example:
+                status: error
+                message: No Survey IDs found
   /status:
     get:
       summary: Http Get Status
@@ -635,6 +1138,32 @@ components:
       - title
       - guid
       title: SchemaMetadata
+    UnitDataset:
+      properties:
+        dataset_id:
+          type: string
+          title: Dataset Id
+        survey_id:
+          type: string
+          title: Survey Id
+        period_id:
+          type: string
+          title: Period Id
+        form_types:
+          items:
+            type: string
+          type: array
+          title: Form Types
+        data:
+          title: Data
+      type: object
+      required:
+      - dataset_id
+      - survey_id
+      - period_id
+      - form_types
+      - data
+      title: UnitDataset
     ValidationError:
       properties:
         loc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,16 @@ dependencies = [
     "ruff==0.13.2",
     "setuptools==80.9.0",
     "tomlkit==0.13.3",
-    "sds-common==1.0.34",
     "mock-firestore>=0.11.0",
+    "sds-common==1.0.36",
 ]
 
 [[tool.uv.index]]
 name = "sds-repo"
 url = "https://europe-west2-python.pkg.dev/ons-sds-ci/sds-python-packages/simple/"
+
+[tool.uv.sources]
+sds-common = { index = "sds-repo" }
 
 [dependency-groups]
 version-check = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sds"
-version = "2.5.1"
+version = "2.6.0"
 description = "Supplementary Data Service"
 requires-python = ">=3.13,<3.14"
 dependencies = [

--- a/tests/integration_tests/datasets/dataset_endpoints_integration_test.py
+++ b/tests/integration_tests/datasets/dataset_endpoints_integration_test.py
@@ -1,8 +1,12 @@
+import os
+
 import pytest
 
 from app.config import settings
 
 from tests.integration_tests.helpers.utils import make_iap_request
+from tests.test_config.endpoints import ENDPOINTS, GET_DATASET_METADATA, GET_ALL_DATASET_METADATA, GET_UNIT_DATA
+from tests.test_config.endpoints_loader import EndpointsLoader
 from tests.test_data.dataset_test_data import (
     dataset_metadata_collection_for_endpoints_test, 
     dataset_unit_data_collection_for_endpoints_test,
@@ -10,6 +14,8 @@ from tests.test_data.dataset_test_data import (
     dataset_404_test_data,
     random_string,
 )
+
+endpoints_loader = EndpointsLoader(ENDPOINTS)
 
 
 class TestDatasetEndpoints:
@@ -27,13 +33,15 @@ class TestDatasetEndpoints:
         - Sends a GET request to retrieve metadata for a dataset
         - Asserts the metadata retrieved matches the expected structure.
         """
-
-        response = make_iap_request(
-            "GET",
-            f"/v1/dataset_metadata?"
-            f"survey_id={dataset_metadata_collection_for_endpoints_test[0].survey_id}&"
-            f"period_id={dataset_metadata_collection_for_endpoints_test[0].period_id}",
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_DATASET_METADATA,
+            params={
+                "survey_id": dataset_metadata_collection_for_endpoints_test[0].survey_id,
+                "period_id": dataset_metadata_collection_for_endpoints_test[0].period_id,
+            }
         )
+
+        response = make_iap_request(method, path=url)
         
         expected_data = [dataset_metadata_collection_for_endpoints_test[0].__dict__]
 
@@ -49,10 +57,11 @@ class TestDatasetEndpoints:
         - Asserts the metadata retrieved matches the expected structure.
         """
 
-        response = make_iap_request(
-            "GET",
-            f"/v1/all_dataset_metadata",
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_ALL_DATASET_METADATA,
         )
+
+        response = make_iap_request(method, path=url)
 
         assert response.status_code == 200
 
@@ -70,12 +79,15 @@ class TestDatasetEndpoints:
         - Get request to retrieve unit data for a dataset
         - Asserts if unit data matches the expected structure
         """
-
-        response = make_iap_request(
-            "GET",
-            f"/v1/unit_data?"
-            f"dataset_id={dataset_unit_data_collection_for_endpoints_test[0].dataset_id}&identifier={dataset_unit_data_id[0]}",
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_UNIT_DATA,
+            params={
+                "dataset_id": dataset_unit_data_collection_for_endpoints_test[0].dataset_id,
+                "identifier": dataset_unit_data_id[0],
+            }
         )
+
+        response = make_iap_request(method=method, path=url)
 
         assert response.status_code == 200
         assert response.json() == dataset_unit_data_collection_for_endpoints_test[0].__dict__
@@ -90,12 +102,15 @@ class TestDatasetEndpoints:
         - Checks if the metadata matches the expected structure without a title
         """
 
-        response = make_iap_request(
-            "GET",
-            f"/v1/dataset_metadata?"
-            f"survey_id={dataset_metadata_collection_for_endpoints_test[1].survey_id}&"
-            f"period_id={dataset_metadata_collection_for_endpoints_test[1].period_id}",
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_DATASET_METADATA,
+            params={
+                "survey_id": dataset_metadata_collection_for_endpoints_test[1].survey_id,
+                "period_id": dataset_metadata_collection_for_endpoints_test[1].period_id,
+            }
         )
+
+        response = make_iap_request(method, path=url)
 
         expected_data = [dataset_metadata_collection_for_endpoints_test[1].__dict__]
 
@@ -111,12 +126,16 @@ class TestDatasetEndpoints:
         - Assert status code is 400
         - Checks the error message in the response
         """
-            
-        response = make_iap_request(
-            "GET",
-            f"/v1/dataset_metadata?"
-            f"period_id={dataset_metadata_collection_for_endpoints_test[0].period_id}",
+
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_DATASET_METADATA,
+            params={
+                "period_id": dataset_metadata_collection_for_endpoints_test[0].period_id,
+            }
         )
+
+        response = make_iap_request(method, path=url)
+
 
         assert response.status_code == 400
         assert response.json()["message"] == "Invalid search parameters provided"
@@ -130,12 +149,15 @@ class TestDatasetEndpoints:
         - Assert status code is 400
         - Checks the error message in the response
         """
-            
-        response = make_iap_request(
-            "GET",
-            f"/v1/dataset_metadata?"
-            f"survey_id={dataset_metadata_collection_for_endpoints_test[0].survey_id}",
+
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_DATASET_METADATA,
+            params={
+                "survey_id": dataset_metadata_collection_for_endpoints_test[0].survey_id,
+            }
         )
+
+        response = make_iap_request(method, path=url)
 
         assert response.status_code == 400
         assert response.json()["message"] == "Invalid search parameters provided"
@@ -149,11 +171,12 @@ class TestDatasetEndpoints:
         - Assert status code is 400
         - Checks the error message in the response
         """
-            
-        response = make_iap_request(
-            "GET",
-            f"/v1/dataset_metadata",
+
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_DATASET_METADATA,
         )
+
+        response = make_iap_request(method, path=url)
 
         assert response.status_code == 400
         assert response.json()["message"] == "Invalid search parameters provided"
@@ -167,12 +190,15 @@ class TestDatasetEndpoints:
         - Assert status code is 400
         - Checks the error message in the response
         """
-            
-        response = make_iap_request(
-            "GET",
-            f"/v1/dataset_metadata?"
-            f"{random_string}",
+
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_DATASET_METADATA,
+            params={
+                "random_string": random_string,
+            }
         )
+
+        response = make_iap_request(method, path=url)
 
         assert response.status_code == 400
         assert response.json()["message"] == "Invalid search parameters provided"
@@ -186,12 +212,16 @@ class TestDatasetEndpoints:
         - Assert status code is 404
         - Checks the error message in the response
         """
-            
-        response = make_iap_request(
-            "GET",
-            f"/v1/dataset_metadata?"
-            f"survey_id={dataset_404_test_data['survey_id']}&period_id={dataset_404_test_data['period_id']}",
+
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_DATASET_METADATA,
+            params={
+                "survey_id": dataset_404_test_data['survey_id'],
+                "period_id": dataset_404_test_data['period_id'],
+            }
         )
+
+        response = make_iap_request(method, path=url)
 
         assert response.status_code == 404
         assert response.json()["message"] == "No datasets found"
@@ -207,13 +237,15 @@ class TestDatasetEndpoints:
         if settings.CONF == "local-int-tests":
             pytest.skip("Skipping test_dataset_metadata_unauthorised on local environment")
 
-        response = make_iap_request(
-            "GET",
-            f"/v1/dataset_metadata?"
-            f"survey_id={dataset_metadata_collection_for_endpoints_test[0].survey_id}&"
-            f"period_id={dataset_metadata_collection_for_endpoints_test[0].period_id}",
-            unauthenticated=True
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_DATASET_METADATA,
+            params={
+                "survey_id": dataset_metadata_collection_for_endpoints_test[0].survey_id,
+                "period_id": dataset_metadata_collection_for_endpoints_test[0].period_id,
+            }
         )
+
+        response = make_iap_request(method, path=url, unauthenticated=True)
 
         assert response.status_code == 401
 
@@ -228,11 +260,11 @@ class TestDatasetEndpoints:
         if settings.CONF == "local-int-tests":
             pytest.skip("Skipping test_all_dataset_metadata_unauthorised on local environment")
 
-        response = make_iap_request(
-            "GET",
-            f"/v1/all_dataset_metadata",
-            unauthenticated=True
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_ALL_DATASET_METADATA,
         )
+
+        response = make_iap_request(method, path=url, unauthenticated=True)
 
         assert response.status_code == 401
 
@@ -245,12 +277,17 @@ class TestDatasetEndpoints:
         - Assert status code is 400
         - Checks the error message in the response
         """
-            
-        response = make_iap_request(
-            "GET",
-            f"/v1/unit_data?"
-            f"identifier={dataset_unit_data_id[0]}",
+        if not endpoints_loader.endpoints_deprecated:
+            pytest.skip("Skipping test_dataset_unit_data_without_dataset_id on new endpoint")
+
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_UNIT_DATA,
+            params={
+                "identifier": dataset_unit_data_id[0],
+            }
         )
+
+        response = make_iap_request(method, path=url)
 
         assert response.status_code == 400
         assert response.json()["message"] == "Validation has failed"
@@ -264,12 +301,17 @@ class TestDatasetEndpoints:
         - Assert status code is 400
         - Checks the error message in the response
         """
-            
-        response = make_iap_request(
-            "GET",
-            f"/v1/unit_data?"
-            f"dataset_id={dataset_unit_data_collection_for_endpoints_test[0].dataset_id}",
+        if not endpoints_loader.endpoints_deprecated:
+            pytest.skip("Skipping test_dataset_unit_data_without_identifier on new endpoint")
+
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_UNIT_DATA,
+            params={
+                "dataset_id": dataset_unit_data_collection_for_endpoints_test[0].dataset_id,
+            }
         )
+
+        response = make_iap_request(method, path=url)
 
         assert response.status_code == 400
         assert response.json()["message"] == "Validation has failed"
@@ -283,12 +325,16 @@ class TestDatasetEndpoints:
         - Assert status code is 404
         - Checks the error message in the response
         """
-            
-        response = make_iap_request(
-            "GET",
-            f"/v1/unit_data?"
-            f"dataset_id={dataset_404_test_data['dataset_id']}&identifier={dataset_404_test_data['identifier']}",
+
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_UNIT_DATA,
+            params={
+                "dataset_id": dataset_404_test_data['dataset_id'],
+                "identifier": dataset_404_test_data['identifier'],
+            }
         )
+
+        response = make_iap_request(method, path=url)
 
         assert response.status_code == 404
         assert response.json()["message"] == "No unit data found"
@@ -304,13 +350,15 @@ class TestDatasetEndpoints:
         if settings.CONF == "local-int-tests":
             pytest.skip("Skipping test_dataset_unit_data_unauthorised on local environment")
 
-        response = make_iap_request(
-            "GET",
-            f"/v1/unit_data?"
-            f"dataset_id={dataset_unit_data_collection_for_endpoints_test[0].dataset_id}&"
-            f"identifier={dataset_unit_data_id[0]}",
-            unauthenticated=True
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_UNIT_DATA,
+            params={
+                "dataset_id": dataset_unit_data_collection_for_endpoints_test[0].dataset_id,
+                "identifier": dataset_unit_data_id[0],
+            }
         )
+
+        response = make_iap_request(method, path=url, unauthenticated=True)
 
         assert response.status_code == 401
 
@@ -323,11 +371,14 @@ class TestDatasetEndpoints:
         - Assert status code is 400
         - Checks the error message in the response
         """
-            
-        response = make_iap_request(
-            "GET",
-            f"/v1/unit_data",
+        if not endpoints_loader.endpoints_deprecated:
+            pytest.skip("Skipping test_dataset_unit_data_no_valid_query_params on new endpoint")
+
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_UNIT_DATA,
         )
+
+        response = make_iap_request(method, path=url)
 
         assert response.status_code == 400
         assert response.json()["message"] == "Validation has failed"
@@ -341,12 +392,17 @@ class TestDatasetEndpoints:
         - Assert status code is 400
         - Checks the error message in the response
         """
-            
-        response = make_iap_request(
-            "GET",
-            f"/v1/unit_data?"
-            f"{random_string}",
+        if not endpoints_loader.endpoints_deprecated:
+            pytest.skip("Skipping test_dataset_unit_data_garbage_query_params on new endpoint")
+
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_UNIT_DATA,
+            params={
+                "random_string": random_string,
+            }
         )
+
+        response = make_iap_request(method, path=url)
 
         assert response.status_code == 400
         assert response.json()["message"] == "Validation has failed"

--- a/tests/integration_tests/schemas/post_schema_integration_test.py
+++ b/tests/integration_tests/schemas/post_schema_integration_test.py
@@ -1,6 +1,10 @@
 from tests.integration_tests.helpers.pubsub_helper import schema_pubsub_helper
 from tests.integration_tests.helpers.utils import make_iap_request
+from tests.test_config.endpoints import ENDPOINTS, POST_SCHEMA
+from tests.test_config.endpoints_loader import EndpointsLoader
 from tests.test_data.shared_test_data import test_schema_subscriber_id, test_survey_id_list
+
+endpoints_loader = EndpointsLoader(ENDPOINTS)
 
 
 class TestPostSchemaEndpoint:
@@ -15,11 +19,14 @@ class TestPostSchemaEndpoint:
         # Post v1 schema for each survey_id - v1 is stored in the second index of the test_schemas list
         for survey_id in test_survey_id_list:
 
-            schema_post_response = make_iap_request(
-                "POST",
-                f"/v1/schema?survey_id={survey_id}",
-                json=test_schema_list[1]
+            url, method = endpoints_loader.formulate_url_and_method(
+                key=POST_SCHEMA,
+                params={
+                    "survey_id": survey_id,
+                }
             )
+
+            schema_post_response = make_iap_request(method, path=url, json=test_schema_list[1])
 
             assert schema_post_response.status_code == 200
             assert "guid" in schema_post_response.json()
@@ -35,11 +42,14 @@ class TestPostSchemaEndpoint:
         # Post v2 schema for each survey_id - v2 is stored in the first index of the test_schemas list
         for survey_id in test_survey_id_list:
 
-            schema_post_response = make_iap_request(
-                "POST",
-                f"/v1/schema?survey_id={survey_id}",
-                json=test_schema_list[0]
+            url, method = endpoints_loader.formulate_url_and_method(
+                key=POST_SCHEMA,
+                params={
+                    "survey_id": survey_id,
+                }
             )
+
+            schema_post_response = make_iap_request(method, path=url, json=test_schema_list[0])
 
             assert schema_post_response.status_code == 200
             assert "guid" in schema_post_response.json()

--- a/tests/integration_tests/schemas/schema_endpoints_integrations_test.py
+++ b/tests/integration_tests/schemas/schema_endpoints_integrations_test.py
@@ -1,11 +1,18 @@
+import os
+
 import pytest
 
 from app.config import settings
 from tests.integration_tests.helpers.integration_helpers import is_json_response
 from tests.integration_tests.helpers.utils import make_iap_request
+from tests.test_config.endpoints import ENDPOINTS, GET_SCHEMA_METADATA, GET_ALL_SCHEMA_METADATA, GET_SCHEMA, \
+    GET_SCHEMA_WITH_GUID, GET_SURVEYS_MAPPING, POST_SCHEMA
+from tests.test_config.endpoints_loader import EndpointsLoader
 from tests.test_data.schema_test_data import test_survey_id_map
 from tests.test_data.shared_test_data import test_survey_id_list
 from tests.test_data.schema_test_data import invalid_survey_id, invalid_data, test_survey_id
+
+endpoints_loader = EndpointsLoader(ENDPOINTS)
 
 
 class TestSchemaEndpoints:
@@ -18,10 +25,16 @@ class TestSchemaEndpoints:
         * We retrieve and verify schema metadata
         """
         for survey_id in test_survey_id_list:
-            schema_metadata_response = make_iap_request(
-                "GET",
-                f"/v1/schema_metadata?survey_id={survey_id}"
+
+            url, method = endpoints_loader.formulate_url_and_method(
+                key=GET_SCHEMA_METADATA,
+                params={
+                    "survey_id": survey_id,
+                }
             )
+
+            schema_metadata_response = make_iap_request(method, url)
+
 
             assert schema_metadata_response.status_code == 200
             schema_metadata_list = schema_metadata_response.json()
@@ -50,11 +63,12 @@ class TestSchemaEndpoints:
 
         * We retrieve and verify all schema metadata
         """
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_ALL_SCHEMA_METADATA,
+        )
 
-        all_schema_metadata_response = make_iap_request(
-                "GET",
-                f"/v1/all_schema_metadata"
-            )
+        all_schema_metadata_response = make_iap_request(method, url)
+
         expected_schema_count = len(test_schema_list) * len(test_survey_id_list)
         assert all_schema_metadata_response.status_code == 200
 
@@ -75,21 +89,28 @@ class TestSchemaEndpoints:
         * We retrieve the latest version of the schema and check the response
         """
         for survey_id in test_survey_id_list:
-
-            # Verify schema retrieval by version
-            set_version_schema_response = make_iap_request(
-                "GET",
-                f"/v1/schema?survey_id={survey_id}&version=1"
+            url, method = endpoints_loader.formulate_url_and_method(
+                key=GET_SCHEMA,
+                params={
+                    "survey_id": survey_id,
+                    "version": "1",
+                }
             )
+
+            set_version_schema_response = make_iap_request(method, url)
 
             assert set_version_schema_response.status_code == 200
             assert set_version_schema_response.json() == test_schema_list[1]
 
             # verify schema retrieval by latest version
-            latest_version_schema_response = make_iap_request(
-                "GET",
-                f"/v1/schema?survey_id={survey_id}"
+            url, method = endpoints_loader.formulate_url_and_method(
+                key=GET_SCHEMA,
+                params={
+                    "survey_id": survey_id,
+                }
             )
+
+            latest_version_schema_response = make_iap_request(method, url)
 
             assert latest_version_schema_response.status_code == 200
             assert latest_version_schema_response.json() == test_schema_list[0]
@@ -102,19 +123,27 @@ class TestSchemaEndpoints:
         * We retrieve the schema by GUID and check the response compared to the expected schema
         """
         for survey_id in test_survey_id_list:
-            schema_metadata_response = make_iap_request(
-                "GET",
-                f"/v1/schema_metadata?survey_id={survey_id}",
+            url, method = endpoints_loader.formulate_url_and_method(
+                key=GET_SCHEMA_METADATA,
+                params={
+                    "survey_id": survey_id,
+                }
             )
+
+            schema_metadata_response = make_iap_request(method, url)
 
             schema_metadata_list = schema_metadata_response.json()
 
             for index, schema_metadata in enumerate(schema_metadata_list):
                 # Verify schema retrieval by GUID
-                set_guid_schema_response = make_iap_request(
-                    "GET",
-                    f"/v2/schema?guid={schema_metadata['guid']}"
+                url, method = endpoints_loader.formulate_url_and_method(
+                    key=GET_SCHEMA_WITH_GUID,
+                    params={
+                        "guid": schema_metadata['guid'],
+                    }
                 )
+
+                set_guid_schema_response = make_iap_request(method, url)
 
                 assert set_guid_schema_response.status_code == 200
                 assert set_guid_schema_response.json() == test_schema_list[index]
@@ -127,11 +156,11 @@ class TestSchemaEndpoints:
 
         * We retrieve the survey mapping data and check the response
         """
-
-        set_survey_id_map_response = make_iap_request(
-            "GET",
-            f"/v1/survey_list"
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_SURVEYS_MAPPING,
         )
+
+        set_survey_id_map_response = make_iap_request(method, url)
 
         assert set_survey_id_map_response.status_code == 200
         assert set_survey_id_map_response.json() == test_survey_id_map
@@ -147,9 +176,16 @@ class TestSchemaEndpoints:
         if settings.CONF == "local-int-tests":
             pytest.skip("Skipping test_post_schema_unauthorized on local environment")
 
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=POST_SCHEMA,
+            params={
+                "survey_id": test_survey_id,
+            }
+        )
+
         response = make_iap_request(
-            "POST",
-            f"/v1/schema?survey_id={test_survey_id}",
+            method=method,
+            path=url,
             json=test_schema_list[0],
             unauthenticated=True
         )
@@ -164,9 +200,16 @@ class TestSchemaEndpoints:
         * We test the POST /v1/schema endpoint by providing invalid data.
         * Assert status code: 400 Bad Request.
         """
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=POST_SCHEMA,
+            params={
+                "survey_id": test_survey_id,
+            }
+        )
+
         response = make_iap_request(
-            "POST",
-            f"/v1/schema?survey_id={test_survey_id}",
+            method=method,
+            path=url,
             json=invalid_data
         )
 
@@ -186,10 +229,14 @@ class TestSchemaEndpoints:
         * We send a request to the GET /v1/schema endpoint providing an invalid survey_id.
         * Assert status code: 404 Not Found.
         """
-        response = make_iap_request(
-            "GET",
-            f"/v1/schema?survey_id={invalid_survey_id}",
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_SCHEMA,
+            params={
+                "survey_id": invalid_survey_id,
+            }
         )
+
+        response = make_iap_request(method, url)
 
         assert response.status_code == 404, f"Unexpected status code: {response.status_code}"
         assert is_json_response(response), "Response is not valid JSON"
@@ -209,9 +256,16 @@ class TestSchemaEndpoints:
         if settings.CONF == "local-int-tests":
             pytest.skip("Skipping test_get_schema_unauthorized on local environment")
 
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_SCHEMA,
+            params={
+                "survey_id": test_survey_id,
+            }
+        )
+
         response = make_iap_request(
-            "GET",
-            f"/v1/schema?survey_id={test_survey_id}",
+            method=method,
+            path=url,
             unauthenticated=True
         )
 
@@ -228,10 +282,11 @@ class TestSchemaEndpoints:
         * Assert status code: 400 Bad Request.
         """
         # Test missing survey_id
-        response = make_iap_request(
-            "GET",
-            f"/v1/schema",
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_SCHEMA,
         )
+
+        response = make_iap_request(method, url)
 
         assert response.status_code == 400, f"Unexpected status code: {response.status_code}"
         assert is_json_response(response), "Response is not valid JSON"
@@ -241,10 +296,13 @@ class TestSchemaEndpoints:
         assert response_data["message"] == "Invalid search provided", f"Unexpected message: {response_data['message']}"
 
         # Test nonsensical parameter
-        response = make_iap_request(
-            "GET",
-            f"/v1/schema_metadata?randomparam=nonsense",
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_SCHEMA,
+            params={
+                "randomparam": "nonsense",
+            }
         )
+        response = make_iap_request(method, url)
 
         assert response.status_code == 400, f"Unexpected status code: {response.status_code}"
         assert is_json_response(response), "Response is not valid JSON"
@@ -264,9 +322,16 @@ class TestSchemaEndpoints:
         if settings.CONF == "local-int-tests":
             pytest.skip("Skipping test_get_schema_metadata_unauthorized on local environment")
 
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_SCHEMA_METADATA,
+            params={
+                "survey_id": test_survey_id,
+            }
+        )
+
         response = make_iap_request(
-                "GET",
-            f"/v1/schema_metadata?survey_id={test_survey_id}",
+            method=method,
+            path=url,
             unauthenticated=True
         )
 
@@ -281,10 +346,11 @@ class TestSchemaEndpoints:
         * Assert status code: 400 Bad Request.
         """
         #Missing survey_id
-        response = make_iap_request(
-            "GET",
-            f"/v1/schema_metadata",
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_SCHEMA_METADATA,
         )
+
+        response = make_iap_request(method, url)
 
         assert response.status_code == 400, f"Unexpected status code: {response.status_code}"
         assert is_json_response(response), "Response is not valid JSON"
@@ -294,10 +360,14 @@ class TestSchemaEndpoints:
         assert response_data["message"] == "Invalid search provided", f"Unexpected message: {response_data['message']}"
 
         #Nonsensical parameter
-        response = make_iap_request(
-            "GET",
-            f"/v1/schema_metadata?invalidparam=123",
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_SCHEMA_METADATA,
+            params={
+                "invalidparam": "123",
+            }
         )
+
+        response = make_iap_request(method, url)
 
         assert response.status_code == 400, f"Unexpected status code: {response.status_code}"
         assert is_json_response(response), "Response is not valid JSON"
@@ -314,10 +384,15 @@ class TestSchemaEndpoints:
         * We send a request to the GET /v1/schema_metadata endpoint providing an invalid survey_id.
         * Assert status code: 404 Not Found.
         """
-        response = make_iap_request(
-            "GET",
-            f"/v1/schema_metadata?survey_id={invalid_survey_id}",
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_SCHEMA_METADATA,
+            params={
+                "survey_id": invalid_survey_id,
+            }
         )
+
+        response = make_iap_request(method, url)
+
         assert response.status_code == 404, f"Unexpected status code: {response.status_code}"
         assert is_json_response(response), "Response is not valid JSON"
 
@@ -336,9 +411,13 @@ class TestSchemaEndpoints:
         if settings.CONF == "local-int-tests":
             pytest.skip("Skipping test_get_all_schema_metadata_unauthorized on local environment")
 
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_ALL_SCHEMA_METADATA,
+        )
+
         response = make_iap_request(
-            "GET",
-            f"/v1/all_schema_metadata",
+            method=method,
+            path=url,
             unauthenticated=True
         )
 
@@ -355,9 +434,16 @@ class TestSchemaEndpoints:
         if settings.CONF == "local-int-tests":
             pytest.skip("Skipping test_get_schema_v2_unauthorized on local environment")
 
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_SCHEMA_WITH_GUID,
+            params={
+                "guid": "some_guid",
+            }
+        )
+
         response = make_iap_request(
-            "GET",
-            f"/v2/schema?guid=invalid_guid",
+            method=method,
+            path=url,
             unauthenticated=True
         )
 
@@ -371,10 +457,14 @@ class TestSchemaEndpoints:
         * We test the GET /v2/schema endpoint by providing an invalid GUID.
         * Assert status code: 400 Bad Request.
         """
-        response = make_iap_request(
-            "GET",
-            f"/v2/schema",
+        if not endpoints_loader.endpoints_deprecated:
+            pytest.skip("Skipping test_get_schema_v2_validation_error on new endpoint")
+
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_SCHEMA_WITH_GUID,
         )
+
+        response = make_iap_request(method, url)
 
         assert response.status_code == 400, f"Unexpected status code: {response.status_code}"
         assert is_json_response(response), "Response is not valid JSON"
@@ -391,10 +481,14 @@ class TestSchemaEndpoints:
         * We send a request to the GET /v2/schema endpoint providing an invalid GUID.
         * Assert status code: 404 Not Found.
         """
-        response = make_iap_request(
-            "GET",
-            f"/v2/schema?guid=nonexistent_guid",
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_SCHEMA_WITH_GUID,
+            params={
+                "guid": "nonexistent_guid",
+            }
         )
+
+        response = make_iap_request(method, url)
 
         assert response.status_code == 404, f"Unexpected status code: {response.status_code}"
         assert is_json_response(response), "Response is not valid JSON"

--- a/tests/integration_tests/status/status_router_integration_test.py
+++ b/tests/integration_tests/status/status_router_integration_test.py
@@ -4,6 +4,10 @@ import pytest
 from app.config import settings
 
 from tests.integration_tests.helpers.utils import make_iap_request
+from tests.test_config.endpoints import ENDPOINTS, GET_STATUS
+from tests.test_config.endpoints_loader import EndpointsLoader
+
+endpoints_loader = EndpointsLoader(ENDPOINTS)
 
 
 class TestHttpGetDeploymentStatus:
@@ -17,10 +21,11 @@ class TestHttpGetDeploymentStatus:
         - Asserts the response status code is 200
         - Asserts the response body contains the right version and status
         """
-        status_response = make_iap_request(
-            "GET",
-            f"/status",
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_STATUS,
         )
+
+        status_response = make_iap_request(method, url)
 
         response_as_json = status_response.json()
 
@@ -39,9 +44,13 @@ class TestHttpGetDeploymentStatus:
         if settings.CONF == "local-int-tests":
             pytest.skip("Skipping test_endpoint_returns_unauthorized_request on local environment")
 
+        url, method = endpoints_loader.formulate_url_and_method(
+            key=GET_STATUS,
+        )
+
         status_response = make_iap_request(
-            "GET",
-            f"/status",
+            method=method,
+            path=url,
             unauthenticated=True
         )
 

--- a/tests/test_config/endpoints.py
+++ b/tests/test_config/endpoints.py
@@ -94,7 +94,7 @@ ENDPOINTS_DEPRECATED: dict[str, EndpointConfig] = {
         "query_parameters": True,
     },
     GET_SCHEMA_WITH_GUID: {
-        "url": f"/v2/schema",
+        "url": "/v2/schema",
         "method": "GET",
         "query_parameters": True,
     },
@@ -109,7 +109,7 @@ ENDPOINTS_DEPRECATED: dict[str, EndpointConfig] = {
         "query_parameters": True,
     },
     GET_UNIT_DATA: {
-        "url": "v1/unit_data",
+        "url": "/v1/unit_data",
         "method": "GET",
         "query_parameters": True,
     },

--- a/tests/test_config/endpoints.py
+++ b/tests/test_config/endpoints.py
@@ -1,0 +1,141 @@
+from typing import TypedDict
+
+POST_SCHEMA: str = "post_schema"
+GET_SCHEMA: str = "get_schema"
+GET_SCHEMA_WITH_GUID: str = "get_schema_with_guid"
+GET_SCHEMA_METADATA: str = "get_schema_metadata"
+GET_DATASET_METADATA: str = "get_dataset_metadata"
+GET_UNIT_DATA: str = "get_unit_data"
+GET_ALL_DATASET_METADATA: str = "get_all_dataset_metadata"
+GET_ALL_SCHEMA_METADATA: str = "get_all_schema_metadata"
+GET_STATUS: str = "get_status"
+COLLECTION_END: str = "collection_end"
+GET_SURVEYS_MAPPING: str = "get_surveys_mapping"
+
+PLACEHOLDERS: dict[str, str] = {
+    "guid": "{guid}",
+    "dataset_id": "{dataset_id}",
+    "identifier": "{identifier}",
+}
+
+class EndpointConfig(TypedDict):
+    url: str
+    method: str
+    query_parameters: bool
+
+
+ENDPOINTS: dict[str, EndpointConfig] = {
+    POST_SCHEMA: {
+        "url": "/schemas",
+        "method": "POST",
+        "query_parameters": True,
+    },
+    GET_SCHEMA: {
+        "url": "/schemas",
+        "method": "GET",
+        "query_parameters": True,
+    },
+    GET_SCHEMA_WITH_GUID: {
+        "url": f"/schemas/{PLACEHOLDERS['guid']}",
+        "method": "GET",
+        "query_parameters": False,
+    },
+    GET_SCHEMA_METADATA: {
+        "url": "/schemas/metadata",
+        "method": "GET",
+        "query_parameters": True,
+    },
+    GET_DATASET_METADATA: {
+        "url": "/datasets/metadata",
+        "method": "GET",
+        "query_parameters": True,
+    },
+    GET_UNIT_DATA: {
+        "url": f"/datasets/{PLACEHOLDERS['dataset_id']}/unit-data/{PLACEHOLDERS['identifier']}",
+        "method": "GET",
+        "query_parameters": False,
+    },
+    GET_ALL_DATASET_METADATA: {
+        "url": "/datasets/all-metadata",
+        "method": "GET",
+        "query_parameters": False,
+    },
+    GET_ALL_SCHEMA_METADATA: {
+        "url": "/schemas/all-metadata",
+        "method": "GET",
+        "query_parameters": False,
+    },
+    COLLECTION_END: {
+        "url": "/collection-exercises-end",
+        "method": "POST",
+        "query_parameters": False,
+    },
+    GET_SURVEYS_MAPPING: {
+        "url": "/surveys",
+        "method": "GET",
+        "query_parameters": False,
+    },
+    GET_STATUS: {
+        "url": "/status",
+        "method": "GET",
+        "query_parameters": False,
+    }
+}
+
+ENDPOINTS_DEPRECATED: dict[str, EndpointConfig] = {
+    POST_SCHEMA: {
+        "url": "/v1/schema",
+        "method": "POST",
+        "query_parameters": True,
+    },
+    GET_SCHEMA: {
+        "url": "/v1/schema",
+        "method": "GET",
+        "query_parameters": True,
+    },
+    GET_SCHEMA_WITH_GUID: {
+        "url": f"/v2/schema",
+        "method": "GET",
+        "query_parameters": True,
+    },
+    GET_SCHEMA_METADATA: {
+        "url": "/v1/schema_metadata",
+        "method": "GET",
+        "query_parameters": True,
+    },
+    GET_DATASET_METADATA: {
+        "url": "/v1/dataset_metadata",
+        "method": "GET",
+        "query_parameters": True,
+    },
+    GET_UNIT_DATA: {
+        "url": "v1/unit_data",
+        "method": "GET",
+        "query_parameters": True,
+    },
+    GET_ALL_DATASET_METADATA: {
+        "url": "/v1/all_dataset_metadata",
+        "method": "GET",
+        "query_parameters": False,
+    },
+    GET_ALL_SCHEMA_METADATA: {
+        "url": "/v1/all_schema_metadata",
+        "method": "GET",
+        "query_parameters": False,
+    },
+    COLLECTION_END: {
+        "url": "/collection-exercise-end",
+        "method": "POST",
+        "query_parameters": False,
+    },
+    GET_SURVEYS_MAPPING: {
+        "url": "/v1/survey_list",
+        "method": "GET",
+        "query_parameters": False,
+    },
+    GET_STATUS: {
+        "url": "/status",
+        "method": "GET",
+        "query_parameters": False,
+    },
+}

--- a/tests/test_config/endpoints_loader.py
+++ b/tests/test_config/endpoints_loader.py
@@ -1,10 +1,13 @@
 import os
 from urllib.parse import quote, urlencode
 
-from tests.test_config.endpoints import ENDPOINTS_DEPRECATED, EndpointConfig, PLACEHOLDERS
+from tests.test_config.endpoints import ENDPOINTS_DEPRECATED, EndpointConfig
 
 
 class EndpointsLoader:
+    endpoints: dict[str, EndpointConfig]
+    endpoints_deprecated: bool
+
     def __init__(self, endpoints: dict[str, EndpointConfig]):
         """
         Load the endpoints config
@@ -17,12 +20,13 @@ class EndpointsLoader:
         # This logic can be removed once the deprecated endpoints are removed.
         if os.environ.get("ENDPOINTS_DEPRECATED") == "true":
             self.endpoints = ENDPOINTS_DEPRECATED
+            self.endpoints_deprecated = True
         else:
             self.endpoints = endpoints
+            self.endpoints_deprecated = False
 
-    def send_request(self, client, key: str, params: dict[str, str] = None, body: dict[str, str]|str = None):
-        url = self.formulate_url(key, params)
-        method = self.endpoints.get(key)["method"]
+    def send_request(self, client, key: str, params: dict[str, str]|None = None, body: dict[str, str]|str|None = None):
+        url, method = self.formulate_url_and_method(key, params)
 
         if method == "GET":
             return client.get(url)
@@ -35,8 +39,9 @@ class EndpointsLoader:
         else:
             raise ValueError(f"Unsupported HTTP method: {method}")
 
-    def formulate_url(self, key: str, params: dict[str, str] = None):
+    def formulate_url_and_method(self, key: str, params: dict[str, str]|None = None) -> tuple[str, str]:
         url = self.endpoints.get(key)["url"]
+        method = self.endpoints.get(key)["method"]
         has_query_parameters = self.endpoints.get(key).get("query_parameters", False)
 
         if params:
@@ -45,7 +50,7 @@ class EndpointsLoader:
             if has_query_parameters:
                 url = f"{url}?{urlencode(encoded_params)}"
 
-        return url
+        return url, method
 
     @staticmethod
     def encode_params(params: dict[str, str]):

--- a/tests/test_config/endpoints_loader.py
+++ b/tests/test_config/endpoints_loader.py
@@ -1,0 +1,58 @@
+import os
+from urllib.parse import quote, urlencode
+
+from tests.test_config.endpoints import ENDPOINTS_DEPRECATED, EndpointConfig, PLACEHOLDERS
+
+
+class EndpointsLoader:
+    def __init__(self, endpoints: dict[str, EndpointConfig]):
+        """
+        Load the endpoints config
+
+        :param endpoints: dictionary containing the endpoint and the url and method for that endpoint
+        """
+
+        # Temporary logic to load deprecated endpoints if `ENDPOINTS_DEPRECATED` environment variable is set to "true".
+        # This allows us to run tests against both the new and deprecated endpoints without needing to change the code in multiple places.
+        # This logic can be removed once the deprecated endpoints are removed.
+        if os.environ.get("ENDPOINTS_DEPRECATED") == "true":
+            self.endpoints = ENDPOINTS_DEPRECATED
+        else:
+            self.endpoints = endpoints
+
+    def send_request(self, client, key: str, params: dict[str, str] = None, body: dict[str, str]|str = None):
+        url = self.formulate_url(key, params)
+        method = self.endpoints.get(key)["method"]
+
+        if method == "GET":
+            return client.get(url)
+        elif method == "POST":
+            return client.post(url, json=body)
+        elif method == "PUT":
+            return client.put(url, json=body)
+        elif method == "DELETE":
+            return client.delete(url)
+        else:
+            raise ValueError(f"Unsupported HTTP method: {method}")
+
+    def formulate_url(self, key: str, params: dict[str, str] = None):
+        url = self.endpoints.get(key)["url"]
+        has_query_parameters = self.endpoints.get(key).get("query_parameters", False)
+
+        if params:
+            encoded_params = self.encode_params(params)
+            url = url.format(**encoded_params)
+            if has_query_parameters:
+                url = f"{url}?{urlencode(encoded_params)}"
+
+        return url
+
+    @staticmethod
+    def encode_params(params: dict[str, str]):
+        """
+        Safely return the params dictionary, or an empty dictionary if None is passed in.
+
+        :param params: dictionary containing the parameters to be used in the URL
+        :return: dictionary containing the parameters to be used in the URL
+        """
+        return {key: quote(str(val)) for key, val in params.items()}

--- a/tests/unit_tests/dataset/get_dataset_metadata_collection_test.py
+++ b/tests/unit_tests/dataset/get_dataset_metadata_collection_test.py
@@ -1,8 +1,12 @@
 from unittest.mock import MagicMock
 from fastapi import status
 
+from tests.test_config.endpoints import ENDPOINTS, GET_DATASET_METADATA, GET_ALL_DATASET_METADATA
+from tests.test_config.endpoints_loader import EndpointsLoader
 from tests.test_data import dataset_test_data, shared_test_data
 from tests.unit_tests.helpers.firestore_helpers import setup_mock_data
+
+endpoints_loader = EndpointsLoader(ENDPOINTS)
 
 
 def test_get_dataset_metadata_collection_200_response(dataset_collection_mock, test_client):
@@ -30,8 +34,13 @@ def test_get_dataset_metadata_collection_200_response(dataset_collection_mock, t
         mock_guid=shared_test_data.test_guid_3,
     )
 
-    response = test_client.get(
-        f"/v1/dataset_metadata?survey_id={dataset_test_data.test_survey_id}&period_id={dataset_test_data.test_period_id}"
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_DATASET_METADATA,
+        params={
+            "survey_id": dataset_test_data.test_survey_id,
+            "period_id": dataset_test_data.test_period_id
+        },
     )
 
     assert response.status_code == status.HTTP_200_OK
@@ -63,7 +72,10 @@ def test_get_all_dataset_metadata_collection_200_response(dataset_collection_moc
         mock_guid=shared_test_data.test_guid_3,
     )
 
-    response = test_client.get("/v1/all_dataset_metadata")
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_ALL_DATASET_METADATA,
+    )
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == [dataset_metadata.__dict__ for dataset_metadata in dataset_test_data.test_all_dataset_metadata]
@@ -73,7 +85,10 @@ def test_get_all_dataset_metadata_collection_404_response(test_client):
     """
     When no dataset metadata is retrieved from all dataset metadata endpoint there should be a 404 response.
     """
-    response = test_client.get("/v1/all_dataset_metadata")
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_ALL_DATASET_METADATA,
+    )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.json()["message"] == "No datasets found"
@@ -83,8 +98,13 @@ def test_get_dataset_metadata_collection_404_response(test_client):
     """
     When no dataset metadata is retrieved dataset metadata endpoint there should be a 404 response.
     """
-    response = test_client.get(
-        f"/v1/dataset_metadata?survey_id={dataset_test_data.test_survey_id}&period_id={dataset_test_data.test_period_id}"
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_DATASET_METADATA,
+        params={
+            "survey_id": dataset_test_data.test_survey_id,
+            "period_id": dataset_test_data.test_period_id
+        },
     )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -97,7 +117,13 @@ def test_get_dataset_metadata_with_invalid_parameters(test_client):
     non-numeric version and returns a 400 error with appropriate message at
     dataset_metadata endpoint
     """
-    response = test_client.get("/v1/dataset_metadata?invalid_key=076")
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_DATASET_METADATA,
+        params={
+            "invalid_key": "076",
+        },
+    )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json()["message"] == "Invalid search parameters provided"
@@ -109,7 +135,14 @@ def test_get_dataset_metadata_with_invalid_extra_parameters(test_client):
     non-numeric version and returns a 400 error with appropriate message at
     dataset_metadata endpoint
     """
-    response = test_client.get("/v1/dataset_metadata?survey_id=076&invalid_key=456")
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_DATASET_METADATA,
+        params={
+            "survey_id": "076",
+            "invalid_key": "456",
+        },
+    )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json()["message"] == "Invalid search parameters provided"
@@ -125,15 +158,21 @@ def test_global_error(firestore_mock, test_client_no_server_exception):
     """
     firestore_mock.get_datasets_collection = MagicMock(side_effect=Exception)
 
-    response = test_client_no_server_exception.get(
-        f"/v1/dataset_metadata?survey_id={dataset_test_data.test_survey_id}&period_id={dataset_test_data.test_period_id}"
+    response = endpoints_loader.send_request(
+        client=test_client_no_server_exception,
+        key=GET_DATASET_METADATA,
+        params={
+            "survey_id": dataset_test_data.test_survey_id,
+            "period_id": dataset_test_data.test_period_id
+        },
     )
 
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert response.json()["message"] == "Unable to process request"
 
-    response = test_client_no_server_exception.get(
-        f"/v1/all_dataset_metadata"
+    response = endpoints_loader.send_request(
+        client=test_client_no_server_exception,
+        key=GET_ALL_DATASET_METADATA,
     )
 
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR

--- a/tests/unit_tests/dataset/get_unit_supplementary_data_test.py
+++ b/tests/unit_tests/dataset/get_unit_supplementary_data_test.py
@@ -1,9 +1,14 @@
+import os
 from unittest.mock import MagicMock
 
 from fastapi import status
 
+from tests.test_config.endpoints import ENDPOINTS, GET_UNIT_DATA
+from tests.test_config.endpoints_loader import EndpointsLoader
 from tests.test_data import shared_test_data, dataset_test_data
 from tests.unit_tests.helpers.firestore_helpers import setup_mock_data
+
+endpoints_loader = EndpointsLoader(ENDPOINTS)
 
 
 def test_get_unit_supplementary_data_200_response(dataset_collection_mock, test_client):
@@ -21,8 +26,13 @@ def test_get_unit_supplementary_data_200_response(dataset_collection_mock, test_
         sub_collection_guid=dataset_test_data.identifier
     )
 
-    response = test_client.get(
-        f"/v1/unit_data?dataset_id={shared_test_data.test_guid}&identifier={dataset_test_data.identifier}",
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_UNIT_DATA,
+        params={
+            "dataset_id": shared_test_data.test_guid,
+            "identifier": dataset_test_data.identifier
+        },
     )
 
     assert response.status_code == status.HTTP_200_OK
@@ -33,8 +43,13 @@ def test_get_unit_supplementary_data_404_response(test_client):
     """
     The e2e journey for retrieving unit supplementary data from firestore,with repository boundaries mocked
     """
-    response = test_client.get(
-        f"/v1/unit_data?dataset_id={shared_test_data.test_guid}&identifier={dataset_test_data.identifier}"
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_UNIT_DATA,
+        params={
+            "dataset_id": shared_test_data.test_guid,
+            "identifier": dataset_test_data.identifier
+        },
     )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -47,10 +62,18 @@ def test_get_unit_supplementary_data_with_incorrect_key(test_client):
     when incorrect key is used to query unit supplementary data
     at get_unit_supplementary_data endpoint
     """
-    response = test_client.get(f"/v1/unit_data?incorrect_key=123")
+    # This test is only relevant to the deprecated endpoint
+    if os.environ.get("ENDPOINTS_DEPRECATED") == "true":
+        response = endpoints_loader.send_request(
+            client=test_client,
+            key=GET_UNIT_DATA,
+            params={
+                "incorrect_key": "123",
+            },
+        )
 
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json()["message"] == "Validation has failed"
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["message"] == "Validation has failed"
 
 
 def test_global_error(firestore_mock, test_client_no_server_exception):
@@ -63,8 +86,13 @@ def test_global_error(firestore_mock, test_client_no_server_exception):
     """
     firestore_mock.get_datasets_collection = MagicMock(side_effect=Exception)
 
-    response = test_client_no_server_exception.get(
-        f"/v1/unit_data?dataset_id={shared_test_data.test_guid}&identifier={dataset_test_data.identifier}"
+    response = endpoints_loader.send_request(
+        client=test_client_no_server_exception,
+        key=GET_UNIT_DATA,
+        params={
+            "dataset_id": shared_test_data.test_guid,
+            "identifier": dataset_test_data.identifier
+        },
     )
 
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR

--- a/tests/unit_tests/routers/status_router_test.py
+++ b/tests/unit_tests/routers/status_router_test.py
@@ -2,14 +2,21 @@ from unittest.mock import MagicMock
 
 from fastapi import status
 from app.services.shared.utility_functions import UtilityFunctions
+from tests.test_config.endpoints import ENDPOINTS, GET_STATUS
+from tests.test_config.endpoints_loader import EndpointsLoader
+
+endpoints_loader = EndpointsLoader(ENDPOINTS)
 
 
 def test_endpoint_returns_200_if_deployment_successful(test_client):
     """
     Endpoint should return `HTTP_200_OK` if the deployment is successful
     """
-    base_url = "/status"
-    response = test_client.get(base_url)
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_STATUS,
+    )
+
     assert response.status_code == status.HTTP_200_OK
 
 
@@ -18,10 +25,12 @@ def test_endpoint_returns_right_message_if_deployment_successful(test_client):
     Endpoint should return the right response if the deployment is successful
     """
     # mocked `settings` to set the CIR_APPLICATION_VERSION to dev-048783a4
-    base_url = "/status"
     UtilityFunctions.get_application_version = MagicMock()
     UtilityFunctions.get_application_version.return_value = "dev-048783a4"
-    response = test_client.get(base_url)
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_STATUS,
+    )
     expected_message = '{"version":"dev-048783a4","status":"OK"}'
     assert expected_message in response.content.decode("utf-8")
 
@@ -29,14 +38,15 @@ def test_endpoint_returns_right_message_if_deployment_successful(test_client):
 def test_endpoint_returns_500_if_deployment_successful(test_client):
     """
     Endpoint should return `HTTP_500_INTERNAL_SERVER_ERROR` if the env var is
-    None due to a unsuccesful deployment
+    None due to a unsuccessful deployment
     """
     # mocked `settings` to set the SDS_APPLICATION_VERSION to None
-
-    base_url = "/status"
     UtilityFunctions.get_application_version = MagicMock()
     UtilityFunctions.get_application_version.return_value = None
-    response = test_client.get(base_url)
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_STATUS,
+    )
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     expected_message = '{"message":"Internal server error","status":"error"}'
     assert expected_message in response.content.decode("utf-8")

--- a/tests/unit_tests/schema/get_schema_metadata_test.py
+++ b/tests/unit_tests/schema/get_schema_metadata_test.py
@@ -2,8 +2,12 @@ from unittest.mock import MagicMock
 
 from fastapi import status
 
+from tests.test_config.endpoints import ENDPOINTS, GET_SCHEMA_METADATA, GET_ALL_SCHEMA_METADATA
+from tests.test_config.endpoints_loader import EndpointsLoader
 from tests.test_data import schema_test_data
 from tests.unit_tests.helpers.firestore_helpers import setup_mock_data
+
+endpoints_loader = EndpointsLoader(ENDPOINTS)
 
 
 def test_get_schema_metadata_collection_200_response(schema_collection_mock, test_client):
@@ -31,7 +35,13 @@ def test_get_schema_metadata_collection_200_response(schema_collection_mock, tes
         mock_guid=schema_test_data.test_guid_3,
     )
 
-    response = test_client.get(f"/v1/schema_metadata?survey_id={schema_test_data.test_survey_id}")
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_SCHEMA_METADATA,
+        params={
+            "survey_id": schema_test_data.test_survey_id
+        },
+    )
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == [schema_metadata.__dict__ for schema_metadata in schema_test_data.test_schema_metadata]
@@ -43,7 +53,13 @@ def test_get_schema_metadata_with_incorrect_key(test_client):
     when incorrect key is used to query schema metadata
     at get_schemas_metadata endpoint
     """
-    response = test_client.get("/v1/schema_metadata?incorrect_key=123")
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_SCHEMA_METADATA,
+        params={
+            "incorrect_key": "123"
+        },
+    )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json()["message"] == "Invalid search provided"
@@ -55,7 +71,13 @@ def test_get_schema_metadata_with_not_found_error(test_client):
     when schema metadata is not found at get_schemas_metadata
     endpoint
     """
-    response = test_client.get(f"/v1/schema_metadata?survey_id={schema_test_data.test_survey_id}")
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_SCHEMA_METADATA,
+        params={
+            "survey_id": schema_test_data.test_survey_id
+        },
+    )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.json()["message"] == "No results found"
@@ -86,7 +108,10 @@ def test_get_all_schema_metadata_collection_200_response(schema_collection_mock,
         mock_guid=schema_test_data.test_guid_3,
     )
 
-    response = test_client.get("/v1/all_schema_metadata")
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_ALL_SCHEMA_METADATA,
+    )
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == [schema_metadata.__dict__ for schema_metadata in schema_test_data.test_all_schema_metadata]
@@ -96,7 +121,10 @@ def test_get_all_schema_metadata_collection_404_response(test_client):
     """
     When the schema metadata collection is not found in firestore there should be a 404 status code and expected response.
     """
-    response = test_client.get("/v1/all_schema_metadata")
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_ALL_SCHEMA_METADATA,
+    )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.json()["message"] == "No results found"
@@ -112,14 +140,21 @@ def test_global_error(firestore_mock, test_client_no_server_exception):
     """
     firestore_mock.get_schemas_collection = MagicMock(side_effect=Exception)
 
-    response = test_client_no_server_exception.get(
-        f"/v1/schema_metadata?survey_id={schema_test_data.test_survey_id}"
+    response = endpoints_loader.send_request(
+        client=test_client_no_server_exception,
+        key=GET_SCHEMA_METADATA,
+        params={
+            "survey_id": schema_test_data.test_survey_id
+        },
     )
+
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert response.json()["message"] == "Unable to process request"
 
-    response = test_client_no_server_exception.get(
-        f"/v1/all_schema_metadata"
+    response = endpoints_loader.send_request(
+        client=test_client_no_server_exception,
+        key=GET_ALL_SCHEMA_METADATA,
     )
+
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert response.json()["message"] == "Unable to process request"

--- a/tests/unit_tests/schema/get_schema_test.py
+++ b/tests/unit_tests/schema/get_schema_test.py
@@ -1,8 +1,13 @@
+import os
 from unittest.mock import MagicMock
 from fastapi import status
 
+from tests.test_config.endpoints import ENDPOINTS, GET_SCHEMA, GET_SCHEMA_WITH_GUID
+from tests.test_config.endpoints_loader import EndpointsLoader
 from tests.test_data import schema_test_data
 from tests.unit_tests.helpers.firestore_helpers import setup_mock_data
+
+endpoints_loader = EndpointsLoader(ENDPOINTS)
 
 
 def test_get_schema_from_firestore_200_response(schema_collection_mock, test_client):
@@ -19,7 +24,14 @@ def test_get_schema_from_firestore_200_response(schema_collection_mock, test_cli
         sub_collection_guid=schema_test_data.test_guid,
     )
 
-    response = test_client.get(f"/v1/schema?survey_id={schema_test_data.test_survey_id}&version=1")
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_SCHEMA,
+        params={
+            "survey_id": schema_test_data.test_survey_id,
+            "version": "1"
+        },
+    )
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == schema_test_data.test_schema
@@ -40,7 +52,13 @@ def test_get_latest_schema_from_firestore_without_version(schema_collection_mock
         sub_collection_guid=schema_test_data.test_guid,
     )
 
-    response = test_client.get(f"/v1/schema?survey_id={schema_test_data.test_survey_id}")
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_SCHEMA,
+        params={
+            "survey_id": schema_test_data.test_survey_id,
+        },
+    )
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == schema_test_data.test_schema
@@ -61,7 +79,13 @@ def test_get_schema_from_firestore_with_guid(schema_collection_mock, test_client
         sub_collection_guid=schema_test_data.test_guid,
     )
 
-    response = test_client.get(f"/v2/schema?guid={schema_test_data.test_guid}")
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_SCHEMA_WITH_GUID,
+        params={
+            "guid": schema_test_data.test_guid,
+        },
+    )
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == schema_test_data.test_schema
@@ -78,7 +102,14 @@ def test_get_schema_from_firestore_404_response(schema_collection_mock, test_cli
         mock_guid=schema_test_data.test_guid,
     )
 
-    response = test_client.get(f"/v1/schema?survey_id={schema_test_data.test_survey_id}&version=1")
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_SCHEMA,
+        params={
+            "survey_id": schema_test_data.test_survey_id,
+            "version": "1"
+        },
+    )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.json()["message"] == "No schema found"
@@ -88,7 +119,14 @@ def test_get_schema_from_firestore_404_response_with_unfound_metadata(test_clien
     """
     When the guid is not found from firestore there should be a 404 status code and expected response.
     """
-    response = test_client.get(f"/v1/schema?survey_id={schema_test_data.test_survey_id}&version=2")
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_SCHEMA,
+        params={
+            "survey_id": schema_test_data.test_survey_id,
+            "version": "1"
+        },
+    )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.json()["message"] == "No schema found"
@@ -99,7 +137,13 @@ def test_get_latest_schema_from_firestore_without_version_404_response(test_clie
     When the schema is queried without version but no latest schema version is found,
     there should be a 404 status code and expected response
     """
-    response = test_client.get(f"/v1/schema?survey_id={schema_test_data.test_survey_id}")
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_SCHEMA,
+        params={
+            "survey_id": schema_test_data.test_survey_id,
+        },
+    )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.json()["message"] == "No schema found"
@@ -109,7 +153,13 @@ def test_get_schema_from_firestore_with_guid_404_response(test_client):
     """
     When the schema is not found via guid there should be a 404 status code and expected response.
     """
-    response = test_client.get(f"/v2/schema?guid={schema_test_data.test_guid}")
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_SCHEMA_WITH_GUID,
+        params={
+            "guid": schema_test_data.test_guid,
+        },
+    )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.json()["message"] == "No schema found"
@@ -125,9 +175,26 @@ def test_global_error(firestore_mock, test_client_no_server_exception):
     """
     firestore_mock.get_schemas_collection = MagicMock(side_effect=Exception)
 
-    response = test_client_no_server_exception.get(
-        "/v1/schema?survey_id=076&version=123"
+    response = endpoints_loader.send_request(
+        client=test_client_no_server_exception,
+        key=GET_SCHEMA,
+        params={
+            "survey_id": "076",
+            "version": "123",
+        },
     )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert response.json()["message"] == "Unable to process request"
+
+    response = endpoints_loader.send_request(
+        client=test_client_no_server_exception,
+        key=GET_SCHEMA_WITH_GUID,
+        params={
+            "guid": schema_test_data.test_guid,
+        },
+    )
+
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert response.json()["message"] == "Unable to process request"
 
@@ -138,7 +205,14 @@ def test_get_schema_with_invalid_version_error(test_client):
     and returns a 400 error with appropriate message at
     get_schema endpoint
     """
-    response = test_client.get(f"/v1/schema?survey_id={schema_test_data.test_survey_id}&version=xyz")
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_SCHEMA,
+        params={
+            "survey_id": "076",
+            "version": "xyz",
+        },
+    )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json()["message"] == "Invalid search provided"
@@ -149,7 +223,10 @@ def test_get_schema_with_missing_survey_id_error(test_client):
     Checks that fastAPI return 400 error with appropriate msg
     when survey id is missing when querying schema at get schema endpoint
     """
-    response = test_client.get("/v1/schema")
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_SCHEMA,
+    )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json()["message"] == "Invalid search provided"
@@ -160,7 +237,12 @@ def test_get_schema_with_missing_guid_error(test_client):
     Checks that fastAPI return 400 error with appropriate msg
     when guid is missing when querying schema at get schema v2 endpoint
     """
-    response = test_client.get("/v2/schema")
+    # This test is only relevant to the deprecated endpoint
+    if os.environ.get("ENDPOINTS_DEPRECATED") == "true":
+        response = endpoints_loader.send_request(
+            client=test_client,
+            key=GET_SCHEMA_WITH_GUID,
+        )
 
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json()["message"] == "Invalid parameter provided"
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["message"] == "Invalid parameter provided"

--- a/tests/unit_tests/schema/post_schema_test.py
+++ b/tests/unit_tests/schema/post_schema_test.py
@@ -3,18 +3,24 @@ from fastapi import status
 import logging
 
 from app.config import settings
+from tests.test_config.endpoints import ENDPOINTS, POST_SCHEMA
+from tests.test_config.endpoints_loader import EndpointsLoader
 
 from tests.test_data import schema_test_data
 from tests.unit_tests.helpers.firestore_helpers import setup_mock_data
+
+endpoints_loader = EndpointsLoader(ENDPOINTS)
 
 
 def test_200_response_first_schema_version(test_client):
     """
     Tests when there the first version of a schema is posted it should give it version 1 and return 200.
     """
-    response = test_client.post(
-        f"/v1/schema?survey_id={schema_test_data.test_survey_id}",
-        json=schema_test_data.test_schema,
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=POST_SCHEMA,
+        params={"survey_id": schema_test_data.test_survey_id},
+        body=schema_test_data.test_schema,
     )
 
     assert response.status_code == status.HTTP_200_OK
@@ -35,9 +41,11 @@ def test_200_response_updated_schema_version(schema_collection_mock, pubsub_mock
         mock_guid=schema_test_data.test_guid,
     )
 
-    response = test_client.post(
-        f"/v1/schema?survey_id={schema_test_data.test_survey_id}",
-        json=schema_test_data.test_schema,
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=POST_SCHEMA,
+        params={"survey_id": schema_test_data.test_survey_id},
+        body=schema_test_data.test_schema,
     )
 
     assert response.status_code == status.HTTP_200_OK
@@ -56,10 +64,13 @@ def test_post_schema_with_invalid_dict(test_client):
     Checks that fastAPI returns a 400 error with appropriate
     message if the schema is not a valid dictionary.
     """
-    response = test_client.post(
-        "/v1/schema?survey_id=",
-        json="invalid_json",
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=POST_SCHEMA,
+        params={"survey_id": schema_test_data.test_survey_id},
+        body="invalid_json",
     )
+
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json()["message"] == "Validation has failed"
 
@@ -68,10 +79,13 @@ def test_post_schema_with_missing_survey_id_400_response(test_client):
     Checks that fastAPI returns a 400 error with appropriate
     message if the schema is missing mandatory fields.
     """
-    response = test_client.post(
-        "/v1/schema?survey_id=",
-        json=schema_test_data.test_post_schema_body_missing_fields,
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=POST_SCHEMA,
+        params={"survey_id": ""},
+        body=schema_test_data.test_schema,
     )
+
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json()["message"] == "Validation has failed"
 
@@ -80,10 +94,13 @@ def test_post_missing_fields_schema_400_response(test_client):
     Checks that fastAPI returns a 400 error with appropriate
     message if the schema is missing mandatory fields.
     """
-    response = test_client.post(
-        f"/v1/schema?survey_id={schema_test_data.test_survey_id}",
-        json=schema_test_data.test_post_schema_body_missing_fields,
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=POST_SCHEMA,
+        params={"survey_id": schema_test_data.test_survey_id},
+        body=schema_test_data.test_post_schema_body_missing_fields,
     )
+
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json()["message"] == "Validation has failed"
 
@@ -92,10 +109,13 @@ def test_post_empty_fields_schema_400_response(test_client):
     Checks that fastAPI returns a 400 error with appropriate
     message if the schema mandatory fields have null value
     """
-    response = test_client.post(
-        f"/v1/schema?survey_id={schema_test_data.test_survey_id}",
-        json=schema_test_data.test_post_schema_body_empty_properties,
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=POST_SCHEMA,
+        params={"survey_id": schema_test_data.test_survey_id},
+        body=schema_test_data.test_post_schema_body_empty_properties,
     )
+
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json()["message"] == "Validation has failed"
 
@@ -104,10 +124,13 @@ def test_post_invalid_type_fields_schema_400_response(test_client):
     Checks that fastAPI returns a 400 error with appropriate
     message if the schema required fields are not an object
     """
-    response = test_client.post(
-        f"/v1/schema?survey_id={schema_test_data.test_survey_id}",
-        json=schema_test_data.test_post_schema_body_invalid_properties_type,
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=POST_SCHEMA,
+        params={"survey_id": schema_test_data.test_survey_id},
+        body=schema_test_data.test_post_schema_body_invalid_properties_type,
     )
+
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json()["message"] == "Validation has failed"
 
@@ -116,10 +139,13 @@ def test_post_missing_schema_version_400_response(test_client):
     Checks that fastAPI returns a 400 error with appropriate
     message if schema version is missing
     """
-    response = test_client.post(
-        f"/v1/schema?survey_id={schema_test_data.test_survey_id}",
-        json=schema_test_data.test_post_schema_body_missing_schema_version,
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=POST_SCHEMA,
+        params={"survey_id": schema_test_data.test_survey_id},
+        body=schema_test_data.test_post_schema_body_missing_schema_version,
     )
+
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json()["message"] == "Validation has failed"
 
@@ -128,10 +154,13 @@ def test_post_invalid_schema_version_400_response(test_client):
     Checks that fastAPI returns a 400 error with appropriate
     message if schema version is not an object
     """
-    response = test_client.post(
-        f"/v1/schema?survey_id={schema_test_data.test_survey_id}",
-        json=schema_test_data.test_post_schema_body_invalid_schema_version,
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=POST_SCHEMA,
+        params={"survey_id": schema_test_data.test_survey_id},
+        body=schema_test_data.test_post_schema_body_invalid_schema_version,
     )
+
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json()["message"] == "Validation has failed"
 
@@ -140,10 +169,13 @@ def test_post_invalid_schema_version_const_400_response(test_client):
     Checks that fastAPI returns a 400 error with appropriate
     message if schema version const is not a string
     """
-    response = test_client.post(
-        f"/v1/schema?survey_id={schema_test_data.test_survey_id}",
-        json=schema_test_data.test_post_schema_body_invalid_schema_version_const,
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=POST_SCHEMA,
+        params={"survey_id": schema_test_data.test_survey_id},
+        body=schema_test_data.test_post_schema_body_invalid_schema_version_const,
     )
+
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json()["message"] == "Validation has failed"
 
@@ -152,10 +184,13 @@ def test_post_empty_schema_version_const_400_response(test_client):
     Checks that fastAPI returns a 400 error with appropriate
     message if schema version const is empty
     """
-    response = test_client.post(
-        f"/v1/schema?survey_id={schema_test_data.test_survey_id}",
-        json=schema_test_data.test_post_schema_body_empty_schema_version_const,
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=POST_SCHEMA,
+        params={"survey_id": schema_test_data.test_survey_id},
+        body=schema_test_data.test_post_schema_body_empty_schema_version_const,
     )
+
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json()["message"] == "Validation has failed"
 
@@ -164,10 +199,13 @@ def test_post_missing_title_400_response(test_client):
     Checks that fastAPI returns a 400 error with appropriate
     message if title is missing
     """
-    response = test_client.post(
-        f"/v1/schema?survey_id={schema_test_data.test_survey_id}",
-        json=schema_test_data.test_post_schema_body_missing_title,
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=POST_SCHEMA,
+        params={"survey_id": schema_test_data.test_survey_id},
+        body=schema_test_data.test_post_schema_body_missing_title,
     )
+
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json()["message"] == "Validation has failed"
 
@@ -176,10 +214,13 @@ def test_post_empty_title_400_response(test_client):
     Checks that fastAPI returns a 400 error with appropriate
     message if title is empty
     """
-    response = test_client.post(
-        f"/v1/schema?survey_id={schema_test_data.test_survey_id}",
-        json=schema_test_data.test_post_schema_body_empty_title,
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=POST_SCHEMA,
+        params={"survey_id": schema_test_data.test_survey_id},
+        body=schema_test_data.test_post_schema_body_empty_title,
     )
+
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json()["message"] == "Validation has failed"
 
@@ -191,9 +232,11 @@ def test_post_schema_transaction_exception_500_response(firestore_mock, test_cli
     """
     firestore_mock.set_transaction = MagicMock(side_effect=Exception)
 
-    response = test_client.post(
-        f"/v1/schema?survey_id={schema_test_data.test_survey_id}",
-        json=schema_test_data.test_schema,
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=POST_SCHEMA,
+        params={"survey_id": schema_test_data.test_survey_id},
+        body=schema_test_data.test_schema,
     )
 
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
@@ -209,9 +252,11 @@ def test_publish_schema_exception_500_response(
     pubsub_mock.publish_data_to_topic = MagicMock(side_effect=Exception)
 
     with caplog.at_level(logging.ERROR, logger="app.services.schema.schema_processor_service"):
-        response = test_client.post(
-            f"/v1/schema?survey_id={schema_test_data.test_survey_id}",
-            json=schema_test_data.test_schema,
+        response = endpoints_loader.send_request(
+            client=test_client,
+            key=POST_SCHEMA,
+            params={"survey_id": schema_test_data.test_survey_id},
+            body=schema_test_data.test_schema,
         )
 
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR

--- a/tests/unit_tests/service/test_dataset_deletion_service.py
+++ b/tests/unit_tests/service/test_dataset_deletion_service.py
@@ -1,7 +1,11 @@
 from fastapi import status
 
+from tests.test_config.endpoints import ENDPOINTS, COLLECTION_END
+from tests.test_config.endpoints_loader import EndpointsLoader
 from tests.test_data import dataset_test_data, shared_test_data
 from tests.unit_tests.helpers.firestore_helpers import setup_mock_data
+
+endpoints_loader = EndpointsLoader(ENDPOINTS)
 
 
 def test_process_collection_exercise_end_message_through_endpoint(
@@ -31,9 +35,10 @@ def test_process_collection_exercise_end_message_through_endpoint(
         mock_guid=shared_test_data.test_guid_3,
     )
 
-    response = test_client.post(
-        "/collection-exercise-end",
-        json=dataset_test_data.test_data_collection_end.__dict__,
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=COLLECTION_END,
+        body=dataset_test_data.test_data_collection_end.__dict__,
     )
 
     assert response.status_code == status.HTTP_200_OK

--- a/tests/unit_tests/service/test_get_survey_id_map_service.py
+++ b/tests/unit_tests/service/test_get_survey_id_map_service.py
@@ -3,7 +3,11 @@ from fastapi import status
 import requests
 
 from app.services.shared.utility_functions import UtilityFunctions
+from tests.test_config.endpoints import ENDPOINTS, GET_SURVEYS_MAPPING
+from tests.test_config.endpoints_loader import EndpointsLoader
 from tests.test_data import schema_test_data
+
+endpoints_loader = EndpointsLoader(ENDPOINTS)
 
 
 def mock_response(status_code, json_data) -> MagicMock:
@@ -24,7 +28,10 @@ def test_request_survey_id_mapping_200_response(test_client):
         json_data=schema_test_data.test_survey_id_map
     )
 
-    response = test_client.get("/v1/survey_list")
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_SURVEYS_MAPPING,
+    )
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == schema_test_data.test_survey_id_map
@@ -40,7 +47,10 @@ def test_request_survey_id_mapping_empty_list_response(test_client):
         json_data=[]
     )
 
-    response = test_client.get("/v1/survey_list")
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_SURVEYS_MAPPING,
+    )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.json()["message"] == "No Survey IDs found"
@@ -56,7 +66,10 @@ def test_request_survey_id_mapping_404_response(test_client):
         json_data=None
     )
 
-    response = test_client.get("/v1/survey_list")
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_SURVEYS_MAPPING,
+    )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.json()["message"] == "No Survey IDs found"
@@ -68,7 +81,10 @@ def test_get_survey_id_map_500_response(test_client_no_server_exception):
     """
     UtilityFunctions.request_survey_id_mapping = MagicMock(side_effect=Exception)
 
-    response = test_client_no_server_exception.get("/v1/survey_list")
+    response = endpoints_loader.send_request(
+        client=test_client_no_server_exception,
+        key=GET_SURVEYS_MAPPING,
+    )
 
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert response.json()["message"] == "Unable to process request"

--- a/uv.lock
+++ b/uv.lock
@@ -1324,7 +1324,7 @@ wheels = [
 
 [[package]]
 name = "sds"
-version = "2.5.1"
+version = "2.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "coverage" },

--- a/uv.lock
+++ b/uv.lock
@@ -419,7 +419,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-iam"
-version = "2.21.0"
+version = "2.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
@@ -429,9 +429,9 @@ dependencies = [
     { name = "proto-plus" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/0b/037b1e1eb601646d6f49bc06d62094c1d0996b373dcbf70c426c6c51572e/google_cloud_iam-2.21.0.tar.gz", hash = "sha256:fc560527e22b97c6cbfba0797d867cf956c727ba687b586b9aa44d78e92281a3", size = 499038, upload-time = "2026-01-15T13:15:08.243Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/13/d6c3f207c8147768f4b56406c1534bdda034be76712bd960a048412f7001/google_cloud_iam-2.24.0.tar.gz", hash = "sha256:199a2512723abec10a49d581e638ccdf5b8a9671e1d5d6ff3ffeaa727075435f", size = 559063, upload-time = "2026-06-22T23:21:31.061Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/44/02ac4e147ea034a3d641c11b54c9d8d0b80fc1ea6a8b7d6c1588d208d42a/google_cloud_iam-2.21.0-py3-none-any.whl", hash = "sha256:1b4a21302b186a31f3a516ccff303779638308b7c801fb61a2406b6a0c6293c4", size = 458958, upload-time = "2026-01-15T13:13:40.671Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/74/31220c86789d4591aa493652656b83a428dcdd46f62b518e2118f98f76bd/google_cloud_iam-2.24.0-py3-none-any.whl", hash = "sha256:29d52032f774b4d3c01b6d8e1f4a8d029ae61c3bdba60ddac402866be11159db", size = 514860, upload-time = "2026-06-22T23:19:15.287Z" },
 ]
 
 [[package]]
@@ -1379,7 +1379,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = "==1.1.1" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "ruff", specifier = "==0.13.2" },
-    { name = "sds-common", specifier = "==1.0.34" },
+    { name = "sds-common", specifier = "==1.0.36", index = "https://europe-west2-python.pkg.dev/ons-sds-ci/sds-python-packages/simple/" },
     { name = "setuptools", specifier = "==80.9.0" },
     { name = "tomlkit", specifier = "==0.13.3" },
     { name = "uvicorn", specifier = "===0.37.0" },
@@ -1393,7 +1393,7 @@ version-check = [
 
 [[package]]
 name = "sds-common"
-version = "1.0.34"
+version = "1.0.36"
 source = { registry = "https://europe-west2-python.pkg.dev/ons-sds-ci/sds-python-packages/simple/" }
 dependencies = [
     { name = "cloudevents" },
@@ -1412,9 +1412,9 @@ dependencies = [
     { name = "requests" },
     { name = "setuptools" },
 ]
-sdist = { url = "https://europe-west2-python.pkg.dev/ons-sds-ci/sds-python-packages/sds-common/sds_common-1.0.34.tar.gz", hash = "sha256:f48474e7b7fef69bded3fa68298bd17ae10737bd24e37cbbc9b6c55d6d48d4df" }
+sdist = { url = "https://europe-west2-python.pkg.dev/ons-sds-ci/sds-python-packages/sds-common/sds_common-1.0.36.tar.gz", hash = "sha256:d7658531590ce7e824b68ac6e2f23b00377631e44cf4fb00d506e0f79bfd27b5" }
 wheels = [
-    { url = "https://europe-west2-python.pkg.dev/ons-sds-ci/sds-python-packages/sds-common/sds_common-1.0.34-py3-none-any.whl", hash = "sha256:86f33b2904c32a01799098963a352810bbebccdaf1f7834ea2858b0a90f805ec" },
+    { url = "https://europe-west2-python.pkg.dev/ons-sds-ci/sds-python-packages/sds-common/sds_common-1.0.36-py3-none-any.whl", hash = "sha256:097d4682e942518920ef51b6587d1273a13ae962dbcdd0f21a968abf44ac1b1d" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Motivation and Context
To set SDS endpoints name that conforms with REST API naming convention and best practice

### What has changed
Duplicate the routers to a set of new SDS endpoints
Modify the Unit Tests and Integration Tests to work on a endpoint config file so that switching endpoints in test becomes easier

### How to test?
Pass Unit Tests and Integration Tests in both local cloud environments

### Links
https://officefornationalstatistics.atlassian.net/browse/DFTS-1556
https://officefornationalstatistics.atlassian.net/wiki/spaces/SDC/pages/371131159/SDS+endpoints+change

### Screenshots (if appropriate):