### PR TITLE
Dataclass bug fix

### DIFF
--- a/app/repositories/dataset_storage/firestore_dataset_storage_repository.py
+++ b/app/repositories/dataset_storage/firestore_dataset_storage_repository.py
@@ -1,3 +1,5 @@
+from dataclasses import fields
+
 from firebase_admin import firestore
 
 from app.interfaces.dataset_storage_repository_interface import DatasetStorageRepositoryInterface
@@ -6,6 +8,7 @@ from app.models.dataset_models import DatasetMetadata, UnitDataset
 from app.util.firebase_loader import FirebaseLoader
 
 logger = logging.getLogger(__name__)
+UNIT_DATASET_FIELDS = {field.name for field in fields(UnitDataset)}
 
 
 class FirestoreDatasetStorageRepository(DatasetStorageRepositoryInterface):
@@ -23,7 +26,14 @@ class FirestoreDatasetStorageRepository(DatasetStorageRepositoryInterface):
         if not returned_unit_data.exists:
             return None
 
-        return UnitDataset(**returned_unit_data.to_dict())
+        unit_data_dict = returned_unit_data.to_dict()
+
+        # Ensure only fields on the dataclass get unpacked into the UnitDataset model, ignoring any unexpected fields
+        filtered_unit_data_dict = {
+            key: value for key, value in unit_data_dict.items() if key in UNIT_DATASET_FIELDS
+        }
+
+        return UnitDataset(**filtered_unit_data_dict)
 
     def get_metadata(
             self, survey_id: str, period_id: str

--- a/app/repositories/dataset_storage/firestore_dataset_storage_repository.py
+++ b/app/repositories/dataset_storage/firestore_dataset_storage_repository.py
@@ -1,4 +1,5 @@
 from dataclasses import fields
+from typing import Any
 
 from firebase_admin import firestore
 
@@ -8,7 +9,10 @@ from app.models.dataset_models import DatasetMetadata, UnitDataset
 from app.util.firebase_loader import FirebaseLoader
 
 logger = logging.getLogger(__name__)
-UNIT_DATASET_FIELDS = {field.name for field in fields(UnitDataset)}
+
+
+def _dataclass_fields(dataclass_type: type[Any]) -> set[str]:
+    return {field.name for field in fields(dataclass_type)}
 
 
 class FirestoreDatasetStorageRepository(DatasetStorageRepositoryInterface):
@@ -16,6 +20,25 @@ class FirestoreDatasetStorageRepository(DatasetStorageRepositoryInterface):
     def __init__(self, firebase_loader: FirebaseLoader) -> None:
         self.client = firebase_loader.get_client()
         self.datasets_collection = firebase_loader.get_datasets_collection()
+
+    @staticmethod
+    def _create_dataclass(
+            dataclass_type: type[Any], model_data: dict[str, Any], **extra_fields: Any
+    ) -> Any:
+        """
+        Helper method to create dataclass instance, will add
+        fields specified in extra_fields and then remove all fields not in the dataclass
+        :param dataclass_type: data class type
+        :param model_data: model data
+        :param extra_fields: extra fields
+        """
+        data_with_extras = {**model_data, **extra_fields}
+        allowed_fields = _dataclass_fields(dataclass_type)
+        filtered_model_data = {
+            key: value for key, value in data_with_extras.items() if key in allowed_fields
+        }
+
+        return dataclass_type(**filtered_model_data)
 
     def get_unit_supplementary_data(
             self, dataset_id: str, identifier: str
@@ -26,14 +49,7 @@ class FirestoreDatasetStorageRepository(DatasetStorageRepositoryInterface):
         if not returned_unit_data.exists:
             return None
 
-        unit_data_dict = returned_unit_data.to_dict()
-
-        # Ensure only fields on the dataclass get unpacked into the UnitDataset model, ignoring any unexpected fields
-        filtered_unit_data_dict = {
-            key: value for key, value in unit_data_dict.items() if key in UNIT_DATASET_FIELDS
-        }
-
-        return UnitDataset(**filtered_unit_data_dict)
+        return self._create_dataclass(UnitDataset, returned_unit_data.to_dict())
 
     def get_metadata(
             self, survey_id: str, period_id: str
@@ -48,8 +64,11 @@ class FirestoreDatasetStorageRepository(DatasetStorageRepositoryInterface):
         dataset_metadata_list: list[DatasetMetadata] = []
         for dataset_metadata in returned_dataset_metadata:
             metadata_dict = dataset_metadata.to_dict()
-            metadata_dict["dataset_id"] = dataset_metadata.id
-            metadata = DatasetMetadata(**metadata_dict)
+            metadata = self._create_dataclass(
+                DatasetMetadata,
+                metadata_dict,
+                dataset_id=dataset_metadata.id,
+            )
             dataset_metadata_list.append(metadata)
 
         return dataset_metadata_list
@@ -64,8 +83,11 @@ class FirestoreDatasetStorageRepository(DatasetStorageRepositoryInterface):
         dataset_metadata_list: list[DatasetMetadata] = []
         for dataset_metadata in returned_dataset_metadata:
             metadata_dict = dataset_metadata.to_dict()
-            metadata_dict["dataset_id"] = dataset_metadata.id
-            metadata = DatasetMetadata(**metadata_dict)
+            metadata = self._create_dataclass(
+                DatasetMetadata,
+                metadata_dict,
+                dataset_id=dataset_metadata.id,
+            )
             dataset_metadata_list.append(metadata)
 
         return dataset_metadata_list

--- a/app/repositories/dataset_storage/firestore_dataset_storage_repository.py
+++ b/app/repositories/dataset_storage/firestore_dataset_storage_repository.py
@@ -11,10 +11,6 @@ from app.util.firebase_loader import FirebaseLoader
 logger = logging.getLogger(__name__)
 
 
-def _dataclass_fields(dataclass_type: type[Any]) -> set[str]:
-    return {field.name for field in fields(dataclass_type)}
-
-
 class FirestoreDatasetStorageRepository(DatasetStorageRepositoryInterface):
 
     def __init__(self, firebase_loader: FirebaseLoader) -> None:
@@ -33,7 +29,7 @@ class FirestoreDatasetStorageRepository(DatasetStorageRepositoryInterface):
         :param extra_fields: extra fields
         """
         data_with_extras = {**model_data, **extra_fields}
-        allowed_fields = _dataclass_fields(dataclass_type)
+        allowed_fields = {field.name for field in fields(dataclass_type)}
         filtered_model_data = {
             key: value for key, value in data_with_extras.items() if key in allowed_fields
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sds"
-version = "2.6.1"
+version = "2.6.2"
 description = "Supplementary Data Service"
 requires-python = ">=3.13,<3.14"
 dependencies = [

--- a/tests/unit_tests/dataset/get_dataset_metadata_collection_test.py
+++ b/tests/unit_tests/dataset/get_dataset_metadata_collection_test.py
@@ -47,6 +47,41 @@ def test_get_dataset_metadata_collection_200_response(dataset_collection_mock, t
     assert response.json() == [dataset_metadata.__dict__ for dataset_metadata in dataset_test_data.test_dataset_metadata]
 
 
+def test_get_dataset_metadata_collection_ignores_unexpected_fields(dataset_collection_mock, test_client):
+    """
+    When Firestore metadata documents include unsupported fields, endpoint should
+    still return 200 and map only DatasetMetadata fields.
+    """
+    metadata_with_unexpected_fields = {
+        **dataset_test_data.test_dataset_metadata_1.__dict__,
+        "schema_version": "1.0.0",
+    }
+
+    setup_mock_data(
+        mock_collection=dataset_collection_mock,
+        mock_data=metadata_with_unexpected_fields,
+        mock_guid=shared_test_data.test_guid,
+    )
+
+    setup_mock_data(
+        mock_collection=dataset_collection_mock,
+        mock_data=dataset_test_data.test_dataset_metadata_2.__dict__,
+        mock_guid=shared_test_data.test_guid_2,
+    )
+
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_DATASET_METADATA,
+        params={
+            "survey_id": dataset_test_data.test_survey_id,
+            "period_id": dataset_test_data.test_period_id,
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == [dataset_metadata.__dict__ for dataset_metadata in dataset_test_data.test_dataset_metadata]
+
+
 def test_get_all_dataset_metadata_collection_200_response(dataset_collection_mock, test_client):
     """
     When the dataset metadata collection is retrieved successfully there should be a 200 status code and expected response
@@ -69,6 +104,43 @@ def test_get_all_dataset_metadata_collection_200_response(dataset_collection_moc
     setup_mock_data(
         mock_collection=dataset_collection_mock,
         mock_data=dataset_test_data.test_dataset_metadata_other.__dict__,
+        mock_guid=shared_test_data.test_guid_3,
+    )
+
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_ALL_DATASET_METADATA,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == [dataset_metadata.__dict__ for dataset_metadata in dataset_test_data.test_all_dataset_metadata]
+
+
+def test_get_all_dataset_metadata_collection_ignores_unexpected_fields(dataset_collection_mock, test_client):
+    """
+    When Firestore metadata documents include unsupported fields, all metadata
+    endpoint should still return 200 and map only DatasetMetadata fields.
+    """
+    metadata_with_unexpected_fields = {
+        **dataset_test_data.test_dataset_metadata_other.__dict__,
+        "schema_version": "2.0.0",
+    }
+
+    setup_mock_data(
+        mock_collection=dataset_collection_mock,
+        mock_data=dataset_test_data.test_dataset_metadata_1.__dict__,
+        mock_guid=shared_test_data.test_guid,
+    )
+
+    setup_mock_data(
+        mock_collection=dataset_collection_mock,
+        mock_data=dataset_test_data.test_dataset_metadata_2.__dict__,
+        mock_guid=shared_test_data.test_guid_2,
+    )
+
+    setup_mock_data(
+        mock_collection=dataset_collection_mock,
+        mock_data=metadata_with_unexpected_fields,
         mock_guid=shared_test_data.test_guid_3,
     )
 

--- a/tests/unit_tests/dataset/get_unit_supplementary_data_test.py
+++ b/tests/unit_tests/dataset/get_unit_supplementary_data_test.py
@@ -39,6 +39,38 @@ def test_get_unit_supplementary_data_200_response(dataset_collection_mock, test_
     assert response.json() == dataset_test_data.test_unit_data.__dict__
 
 
+def test_get_unit_supplementary_data_ignores_unexpected_fields(dataset_collection_mock, test_client):
+    """
+    When Firestore unit data includes fields outside UnitDataset, endpoint should
+    still return 200 and map only expected UnitDataset fields.
+    """
+    unit_data_with_unexpected_fields = {
+        **dataset_test_data.test_unit_data.__dict__,
+        "schema_version": "v1",
+    }
+
+    setup_mock_data(
+        mock_collection=dataset_collection_mock,
+        mock_data=dataset_test_data.test_dataset_metadata_1.__dict__,
+        mock_guid=shared_test_data.test_guid,
+        sub_collection_name=dataset_test_data.sub_collection_name,
+        sub_collection_data=unit_data_with_unexpected_fields,
+        sub_collection_guid=dataset_test_data.identifier,
+    )
+
+    response = endpoints_loader.send_request(
+        client=test_client,
+        key=GET_UNIT_DATA,
+        params={
+            "dataset_id": shared_test_data.test_guid,
+            "identifier": dataset_test_data.identifier,
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == dataset_test_data.test_unit_data.__dict__
+
+
 def test_get_unit_supplementary_data_404_response(test_client):
     """
     The e2e journey for retrieving unit supplementary data from firestore,with repository boundaries mocked

--- a/uv.lock
+++ b/uv.lock
@@ -1324,7 +1324,7 @@ wheels = [
 
 [[package]]
 name = "sds"
-version = "2.6.1"
+version = "2.6.2"
 source = { virtual = "." }
 dependencies = [
     { name = "coverage" },


### PR DESCRIPTION
### Motivation and Context

If a field that is not in the UnitDataset dataclass is passed to this dataclass, the code breaks. This will occur if a legacy dataset is retrieved that contains a field that is deprecated. e.g `schema_version`

### What has changed

The code now filters out all fields that are not in the UnitDataset before creating the UnitDataset. 

### How to test?

Run the tests
